### PR TITLE
Updates for CKAN 2.8.5 docker updates

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -1,0 +1,15 @@
+dependencies:
+- name: redis
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 10.5.6
+- name: solr
+  repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+  version: 1.4.0
+- name: postgresql
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 8.6.4
+- name: datapusher
+  repository: file://dependency-charts/datapusher
+  version: 1.0.0
+digest: sha256:bf437d2c5f4da6ca447116a7c3d8b520443ba12f3528f2cca6a37b844dbfd319
+generated: "2020-09-24T15:39:58.767117823+02:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -38,8 +38,4 @@ dependencies:
     version: "1.0.0"
     repository: "file://dependency-charts/datapusher"
     condition: datapusher.enabled
-  - name: minio
-    version: "5.0.27"
-    repository: "https://kubernetes-charts.storage.googleapis.com/"
-    condition: minio.enabled
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -18,7 +18,7 @@ version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.8.4
+appVersion: 2.8.5
 
 # Dependencies
 dependencies:

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Two jobs for initializing Postgres and SOLR can also be enabled through the valu
 | datapusher.enabled | bool | `true` | Flag to control whether to deploy the datapusher |
 | datapusher.fullnameOverride | string | `"datapusher"` | Name override for the datapusher deployment |
 | fullnameOverride | string | `"ckan"` |  |
-| image.pullPolicy | string | `"Always"` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"keitaro/ckan"` |  |
 | image.tag | string | `"2.8.5"` |  |
 | imagePullSecrets | list | `[]` |  |

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Two jobs for initializing Postgres and SOLR can also be enabled through the valu
 |------------|------|---------|
 | file://dependency-charts/datapusher | datapusher | 1.0.0 |
 | https://kubernetes-charts-incubator.storage.googleapis.com/ | solr | 1.4.0 |
-| https://kubernetes-charts.storage.googleapis.com/ | minio | 5.0.27 |
 | https://kubernetes-charts.storage.googleapis.com/ | postgresql | 8.6.4 |
 | https://kubernetes-charts.storage.googleapis.com/ | redis | 10.5.6 |
 
@@ -37,18 +36,11 @@ Two jobs for initializing Postgres and SOLR can also be enabled through the valu
 | MasterDBPass | string | `"pass"` | Variable for password for the master user in PostgreSQL |
 | MasterDBUser | string | `"postgres"` | Variable for master user name for PostgreSQL |
 | RedisName | string | `"redis"` | Variable for name override for redis deployment |
-| S3AclSetting | string | `"private"` | ACL setting for the S3 bucket |
-| S3FileStoreAccessKey | string | `"minio_admin"` | AWS access key |
-| S3FileStoreBucketName | string | `"ckan"` | AWS bucket name |
-| S3FileStoreHostName | string | `"http://minio:9000"` | Bucket host name |
-| S3FileStoreRegionName | string | `"minio"` | Bucket region name |
-| S3FileStoreSecretKey | string | `"minio_pass"` | AWS secret key |
-| S3FileStoreSignatureVersion | string | `"s3v4"` | S3 signature version |
-| S3FileStoreStoragePath | string | `"ckan_storage"` | S3 storage path |
 | SolrName | string | `"solr"` | Variable for name override for solr deployment |
 | affinity | object | `{}` |  |
 | ckan.activityStreamsEmailNotifications | string | `"true"` |  |
-| ckan.ckanPlugins | string | `"envvars s3filestore image_view text_view recline_view datastore datapusher"` | List of plugins to be used by the instance |
+| ckan.ckanPlugins | string | `"envvars image_view text_view recline_view datastore datapusher"` | List of plugins to be used by the instance |
+| ckan.datapusherCallbackUrlBase | string | `"http://ckan"` | Location of the CKAN k8s service to be used by the Datapusher, overriding the default site url route. |
 | ckan.datapusherUrl | string | `"http://datapusher-headless:8000"` | Location of the datapusher service to be used by the CKAN instance |
 | ckan.datastore.RoDbName | string | `"datastore_default"` | Name of the database to be used for Datastore |
 | ckan.datastore.RoDbPassword | string | `"pass"` | Password for the datastore read permissions user |
@@ -80,14 +72,6 @@ Two jobs for initializing Postgres and SOLR can also be enabled through the valu
 | ckan.readiness.periodSeconds | int | `10` |  |
 | ckan.readiness.timeoutSeconds | int | `10` | Timeout interval for the readiness probe |
 | ckan.redis | string | `"redis://redis-headless:6379/0"` | Location of the Redis service to be used by the CKAN instance |
-| ckan.s3filestore.acl | string | `"private"` | ACL setting for the S3 bucket. Possible values: `'private'|'public-read'|'public-read-write'|'authenticated-read'|'aws-exec-read'|'bucket-owner-read'|'bucket-owner-full-control'` |
-| ckan.s3filestore.awsAccessKeyId | string | `"minio_admin"` | AWS access key |
-| ckan.s3filestore.awsBucketName | string | `"ckan"` | S3 bucket name |
-| ckan.s3filestore.awsSecretAccessKey | string | `"minio_pass"` | AWS secret key |
-| ckan.s3filestore.awsStoragePath | string | `"ckan_storage"` | S3 storage path |
-| ckan.s3filestore.hostName | string | `"http://minio:9000"` | S3 host name |
-| ckan.s3filestore.regionName | string | `"minio"` | S3 region name |
-| ckan.s3filestore.signatureVersion | string | `"s3v4"` | S3 signature version |
 | ckan.siteId | string | `"site-id-here"` | Site id |
 | ckan.siteTitle | string | `"Site Title here"` | Site title for the instance |
 | ckan.siteUrl | string | `"http://localhost:5000"` | Url for the CKAN instance |
@@ -103,28 +87,25 @@ Two jobs for initializing Postgres and SOLR can also be enabled through the valu
 | ckan.sysadminEmail | string | `"admin@domain.com"` | CKAN system admin email |
 | ckan.sysadminName | string | `"ckan_admin"` | CKAN system admin username |
 | ckan.sysadminPassword | string | `"PasswordHere"` | CKAN system admin password |
+| datapusher.datapusher.chunkSize | string | `"10240000"` | Size of chunks of the data that is being downloaded in bytes |
+| datapusher.datapusher.datapusherRewriteResources | string | `"True"` | Enable or disable (boolean) whether datapusher should rewrite resources uploaded to CKAN's filestore, since datapusher takes the CKAN Site URL value for generating the resource URL. Default: False |
+| datapusher.datapusher.datapusherRewriteUrl | string | `"http://ckan"` | Sets the rewrite URL that datapushed will rewrite resources that are uploaded to CKAN's filestore. Default: http://ckan:5000 |
+| datapusher.datapusher.datapusherSslVerify | string | `"False"` | Enable or disable (boolean) verification of SSL when trying to get resources. Default: True |
+| datapusher.datapusher.downloadTimeout | string | `"300"` | Timeout limit of the download request |
+| datapusher.datapusher.insertRows | string | `"50000"` | Number of rows to take from the data and upload them as chunks to datastore |
+| datapusher.datapusher.maxContentLength | string | `"102400000"` |  |
 | datapusher.enabled | bool | `true` | Flag to control whether to deploy the datapusher |
 | datapusher.fullnameOverride | string | `"datapusher"` | Name override for the datapusher deployment |
 | fullnameOverride | string | `"ckan"` |  |
 | image.pullPolicy | string | `"Always"` |  |
 | image.repository | string | `"keitaro/ckan"` |  |
-| image.tag | string | `"2.8.4"` |  |
+| image.tag | string | `"2.8.5"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |
 | ingress.hosts[0].host | string | `"chart-example.local"` |  |
 | ingress.hosts[0].paths | list | `[]` |  |
 | ingress.tls | list | `[]` |  |
-| minio.accessKey | string | `"minio_admin"` | Access key for minio |
-| minio.defaultBucket.enabled | bool | `true` | Flag to control whether to create default bucket |
-| minio.defaultBucket.name | string | `"ckan"` | Name of the default Minio bucket |
-| minio.defaultBucket.policy | string | `"upload"` | Policy of the default Minio bucket |
-| minio.enabled | bool | `true` | Flag to control whether to deploy Minio |
-| minio.fullnameOverride | string | `"minio"` | Name override for the Minio deployment |
-| minio.persistence.size | string | `"5Gi"` | Size of the Minio PVC |
-| minio.secretKey | string | `"minio_pass"` | Secret key for minio |
-| minio.service.port | int | `9000` | The port used by the Mino service |
-| minio.service.type | string | `"NodePort"` | The service type of the Minio service |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
@@ -133,7 +114,7 @@ Two jobs for initializing Postgres and SOLR can also be enabled through the valu
 | postgresql.fullnameOverride | string | `"postgres"` | Name override for the PostgreSQL deployment |
 | postgresql.persistence.size | string | `"1Gi"` | Size of the PostgreSQL pvc |
 | postgresql.pgPass | string | `"pass"` | Password for the master PostgreSQL user. Feeds into the `postgrescredentials` secret that is provided to the PostgreSQL chart |
-| pvc.enabled | string | `"false"` |  |
+| pvc.enabled | bool | `true` |  |
 | pvc.size | string | `"1Gi"` |  |
 | redis.cluster.enabled | bool | `false` | Cluster mode for Redis |
 | redis.enabled | bool | `true` | Flag to control whether to deploy Redis |
@@ -160,6 +141,6 @@ Two jobs for initializing Postgres and SOLR can also be enabled through the valu
 | solr.initialize.replicationFactor | int | `1` | Number of replicas for each SOLR shard |
 | solr.replicaCount | int | `1` | Number of SOLR instances in the cluster |
 | solr.volumeClaimTemplates.storageSize | string | `"5Gi"` | Size of Solr PVC |
-| solr.zookeeper.replicaCount | int | `1` | Numer of Zookeeper replicas in the ZK cluster |
 | solr.zookeeper.persistence.size | string | `"1Gi"` | Size of ZK PVC |
+| solr.zookeeper.replicaCount | int | `1` | Numer of Zookeeper replicas in the ZK cluster |
 | tolerations | list | `[]` |  |

--- a/dependency-charts/datapusher/Chart.yaml
+++ b/dependency-charts/datapusher/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.0.16
+appVersion: 0.0.17

--- a/dependency-charts/datapusher/README.md
+++ b/dependency-charts/datapusher/README.md
@@ -21,8 +21,9 @@ Current chart version is `1.0.0`
 | datapusher.insertRows | string | `"250"` | Number of rows to take from the data and upload them as chunks to datastore |
 | datapusher.maxContentLength | string | `"10485760"` | Maximum size of content to be uploaded in bytes. |
 | fullnameOverride | string | `""` |  |
-| image.pullPolicy | string | `"Always"` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"keitaro/ckan-datapusher"` |  |
+| image.tag | string | `"0.0.17"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |

--- a/dependency-charts/datapusher/README.md
+++ b/dependency-charts/datapusher/README.md
@@ -13,8 +13,15 @@ Current chart version is `1.0.0`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| datapusher.chunkSize | string | `"16384"` | Size of chunks of the data that is being downloaded in bytes |
+| datapusher.datapusherRewriteResources | string | `"True"` | Enable or disable (boolean) whether datapusher should rewrite resources uploaded to CKAN's filestore, since datapusher takes the CKAN Site URL value for generating the resource URL. Default: False |
+| datapusher.datapusherRewriteUrl | string | `"http://ckan"` |  |
+| datapusher.datapusherSslVerify | string | `"False"` | Enable or disable (boolean) verification of SSL when trying to get resources. Default: True |
+| datapusher.downloadTimeout | string | `"30"` | Timeout limit of the download request |
+| datapusher.insertRows | string | `"250"` | Number of rows to take from the data and upload them as chunks to datastore |
+| datapusher.maxContentLength | string | `"10485760"` | Maximum size of content to be uploaded in bytes. |
 | fullnameOverride | string | `""` |  |
-| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.pullPolicy | string | `"Always"` |  |
 | image.repository | string | `"keitaro/ckan-datapusher"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |

--- a/dependency-charts/datapusher/templates/deployment.yaml
+++ b/dependency-charts/datapusher/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/dependency-charts/datapusher/templates/deployment.yaml
+++ b/dependency-charts/datapusher/templates/deployment.yaml
@@ -31,6 +31,15 @@ spec:
             - name: http
               containerPort: 8000
               protocol: TCP
+          env:
+            - name: DATAPUSHER_MAX_CONTENT_LENGTH
+              value: {{ .Values.datapusher.maxContentLength | quote }}
+            - name: DATAPUSHER_CHUNK_SIZE
+              value: {{ .Values.datapusher.chunkSize | quote }}
+            - name: DATAPUSHER_CHUNK_INSERT_ROWS
+              value: {{ .Values.datapusher.insertRows | quote }}
+            - name: DATAPUSHER_DOWNLOAD_TIMEOUT
+              value: {{ .Values.datapusher.downloadTimeout | quote }}
           livenessProbe:
             httpGet:
               path: /

--- a/dependency-charts/datapusher/templates/deployment.yaml
+++ b/dependency-charts/datapusher/templates/deployment.yaml
@@ -40,6 +40,12 @@ spec:
               value: {{ .Values.datapusher.insertRows | quote }}
             - name: DATAPUSHER_DOWNLOAD_TIMEOUT
               value: {{ .Values.datapusher.downloadTimeout | quote }}
+            - name: DATAPUSHER_SSL_VERIFY
+              value: {{ .Values.datapusher.datapusherSslVerify | quote }}
+            - name: DATAPUSHER_REWRITE_RESOURCES
+              value: {{ .Values.datapusher.datapusherRewriteResources | quote }}
+            - name: DATAPUSHER_REWRITE_URL
+              value: {{ .Values.datapusher.datapusherRewriteUrl | quote }}
           livenessProbe:
             httpGet:
               path: /

--- a/dependency-charts/datapusher/values.yaml
+++ b/dependency-charts/datapusher/values.yaml
@@ -6,11 +6,21 @@ replicaCount: 1
 
 image:
   repository: keitaro/ckan-datapusher
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
 
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+
+datapusher:
+  # datapusher.maxContentSize -- Maximum size of content to be uploaded in bytes.
+  maxContentLength: "10485760"
+  # datapusher.chunkSize -- Size of chunks of the data that is being downloaded in bytes
+  chunkSize: "16384"
+  # datapusher.insertRows -- Number of rows to take from the data and upload them as chunks to datastore
+  insertRows: "250"
+  # datapusher.downloadTimeout -- Timeout limit of the download request
+  downloadTimeout: "30"
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/dependency-charts/datapusher/values.yaml
+++ b/dependency-charts/datapusher/values.yaml
@@ -6,7 +6,8 @@ replicaCount: 1
 
 image:
   repository: keitaro/ckan-datapusher
-  pullPolicy: Always
+  tag: 0.0.17
+  pullPolicy: IfNotPresent
 
 imagePullSecrets: []
 nameOverride: ""

--- a/dependency-charts/datapusher/values.yaml
+++ b/dependency-charts/datapusher/values.yaml
@@ -13,7 +13,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 datapusher:
-  # datapusher.maxContentSize -- Maximum size of content to be uploaded in bytes.
+  # datapusher.maxContentLength -- Maximum size of content to be uploaded in bytes.
   maxContentLength: "10485760"
   # datapusher.chunkSize -- Size of chunks of the data that is being downloaded in bytes
   chunkSize: "16384"
@@ -21,6 +21,12 @@ datapusher:
   insertRows: "250"
   # datapusher.downloadTimeout -- Timeout limit of the download request
   downloadTimeout: "30"
+  # datapusher.datapusherSslVerify -- Enable or disable (boolean) verification of SSL when trying to get resources. Default: True
+  datapusherSslVerify: "False"
+  # datapusher.datapusherRewriteResources -- Enable or disable (boolean) whether datapusher should rewrite resources uploaded to CKAN's filestore, since datapusher takes the CKAN Site URL value for generating the resource URL. Default: False
+  datapusherRewriteResources: "True"
+  # Sets the rewrite URL that datapushed will rewrite resources that are uploaded to CKAN's filestore. Default: http://ckan:5000
+  datapusherRewriteUrl: http://ckan
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/templates/ckancredentials.yaml
+++ b/templates/ckancredentials.yaml
@@ -10,4 +10,3 @@ stringData:
   ckanDatastoreWriteUrl: "postgresql://{{ .Values.ckan.datastore.RwDbUser }}:{{ .Values.ckan.datastore.RwDbPassword }}@{{ .Values.ckan.datastore.RwDbUrl }}/{{ .Values.ckan.datastore.RwDbName }}"
   ckanDatastoreReadUrl: "postgresql://{{ .Values.ckan.datastore.RoDbUser }}:{{ .Values.ckan.datastore.RoDbPassword }}@{{ .Values.ckan.datastore.RoDbUrl }}/{{ .Values.ckan.datastore.RoDbName }}"
   smtpPassword: {{ .Values.ckan.smtp.password }}
-  awsSecretAccessKey: {{ .Values.ckan.s3filestore.awsSecretAccessKey }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -72,29 +72,6 @@ spec:
               value: {{ .Values.ckan.siteUrl }}
             - name: CKAN__PLUGINS
               value: {{ .Values.ckan.ckanPlugins }}
-            - name: CKANEXT__S3FILESTORE__AWS_ACCESS_KEY_ID
-              value: {{ .Values.ckan.s3filestore.awsAccessKeyId }}
-            - name: CKANEXT__S3FILESTORE__AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: ckancredentials
-                  key: awsSecretAccessKey
-            - name: CKANEXT__S3FILESTORE__AWS_BUCKET_NAME
-              value: {{ .Values.ckan.s3filestore.awsBucketName }}
-            - name: CKANEXT__S3FILESTORE__HOST_NAME
-              value: {{ .Values.ckan.s3filestore.hostName }}
-            - name: CKANEXT__S3FILESTORE__REGION_NAME
-              value: {{ .Values.ckan.s3filestore.regionName }}
-            - name: CKANEXT__S3FILESTORE__SIGNATURE_VERSION
-              value: {{ .Values.ckan.s3filestore.signatureVersion }}
-            - name: CKANEXT__S3FILESTORE__AWS_STORAGE_PATH
-              value: {{ .Values.ckan.s3filestore.awsStoragePath }}
-            - name: CKANEXT__S3FILESTORE__ACL
-              value: {{ .Values.ckan.s3filestore.acl }}
-            - name: CKANEXT__S3FILESTORE__ADDRESSING_STYLE
-              value: {{ .Values.ckan.s3filestore.addressingStyle }}
-            # - name: CKANEXT__S3FILESTORE__FILESYSTEM_DOWNLOAD_FALLBACK
-            #   value: {{ .Values.ckan.s3filestore.filesystemDownloadFallback }}
             - name: CKAN__STORAGE_PATH
               value: {{ .Values.ckan.storagePath }}
             - name: PSQL_MASTER
@@ -133,6 +110,8 @@ spec:
               value: {{ .Values.ckan.locale.default }}
             - name: CKAN__DATAPUSHER__URL
               value: {{ .Values.ckan.datapusherUrl }}
+            - name: CKAN__DATAPUSHER__CALLBACK_URL_BASE
+              value: {{ .Values.ckan.datapusherCallbackUrlBase }}
             - name: CKAN___SMTP__SERVER
               value: {{ .Values.ckan.smtp.server | quote }}
             - name: CKAN___SMTP__USER

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -91,6 +91,8 @@ spec:
               value: {{ .Values.ckan.s3filestore.awsStoragePath }}
             - name: CKANEXT__S3FILESTORE__ACL
               value: {{ .Values.ckan.s3filestore.acl }}
+            - name: CKANEXT__S3FILESTORE__ADDRESSING_STYLE
+              value: {{ .Values.ckan.s3filestore.addressingStyle }}
             # - name: CKANEXT__S3FILESTORE__FILESYSTEM_DOWNLOAD_FALLBACK
             #   value: {{ .Values.ckan.s3filestore.filesystemDownloadFallback }}
             - name: CKAN__STORAGE_PATH

--- a/templates/psql-init-job.yaml
+++ b/templates/psql-init-job.yaml
@@ -12,7 +12,7 @@ spec:
             name: psql-init-configmap
       containers:
       - name: psql-init
-        image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: PSQL_MASTER

--- a/templates/solr-init-job.yaml
+++ b/templates/solr-init-job.yaml
@@ -15,7 +15,7 @@ spec:
             name: solr-configset-configmap
       containers:
       - name: solr-init
-        image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: CKAN_SOLR_URL

--- a/values.yaml
+++ b/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: keitaro/ckan
   tag: 2.8.5
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
 
 imagePullSecrets: []
 nameOverride: ""

--- a/values.yaml
+++ b/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: keitaro/ckan
-  tag: 2.8.4
+  tag: 2.8.5
   pullPolicy: Always
 
 imagePullSecrets: []
@@ -55,25 +55,6 @@ DatastoreRODBUser: &DatastoreRODBUser datastorero
 # DatastoreRODBPass -- Variable for password for the datastore database user with read access
 DatastoreRODBPass: &DatastoreRODBPass pass
 
-# S3FileStoreAccessKey -- AWS access key
-S3FileStoreAccessKey: &S3FileStoreAccessKey "minio_admin"
-# S3FileStoreSecretKey -- AWS secret key
-S3FileStoreSecretKey: &S3FileStoreSecretKey "minio_pass"
-# S3FileStoreBucketName -- AWS bucket name
-S3FileStoreBucketName: &S3FileStoreBucketName ckan
-# S3FileStoreHostName -- Bucket host name
-S3FileStoreHostName: &S3FileStoreHostName "http://minio:9000"
-# S3FileStoreRegionName -- Bucket region name
-S3FileStoreRegionName: &S3FileStoreRegionName "minio"
-# S3FileStoreSignatureVersion -- S3 signature version
-S3FileStoreSignatureVersion: &S3FileStoreSignatureVersion "s3v4"
-# S3FileStoreStoragePath -- S3 storage path
-S3FileStoreStoragePath: &S3FileStoreStoragePath "ckan_storage"
-# S3AclSetting -- ACL setting for the S3 bucket
-S3AclSetting: &S3AclSetting "private"
-# S3AddressingStyle -- Addresing style setting for S3
-S3AddressingStyle: &S3AddressingStyle 'path'
-
 ckan:
   # ckan.sysadminName -- CKAN system admin username
   sysadminName: "ckan_admin"
@@ -88,31 +69,11 @@ ckan:
   # ckan.siteUrl -- Url for the CKAN instance
   siteUrl: "http://localhost:5000"
   # ckan.ckanPlugins -- List of plugins to be used by the instance
-  ckanPlugins: "envvars s3filestore image_view text_view recline_view datastore datapusher"
+  ckanPlugins: "envvars image_view text_view recline_view datastore datapusher"
   # ckan.storagePath -- Storage path to be used by the instance
   storagePath: "/var/lib/ckan/default"
   activityStreamsEmailNotifications: "true"
   debug: "true"
-  s3filestore:
-    # ckan.s3filestore.awsAccessKeyId -- AWS access key
-    awsAccessKeyId: *S3FileStoreAccessKey
-    # ckan.s3filestore.awsSecretAccessKey -- AWS secret key
-    awsSecretAccessKey: *S3FileStoreSecretKey
-    # ckan.s3filestore.awsBucketName -- S3 bucket name
-    awsBucketName: *S3FileStoreBucketName
-    # ckan.s3filestore.hostName -- S3 host name
-    hostName: *S3FileStoreHostName
-    # ckan.s3filestore.regionName -- S3 region name
-    regionName: *S3FileStoreRegionName
-    # ckan.s3filestore.signatureVersion -- S3 signature version
-    signatureVersion: *S3FileStoreSignatureVersion
-    # ckan.s3filestore.awsStoragePath -- S3 storage path
-    awsStoragePath: *S3FileStoreStoragePath 
-    # ckan.s3filestore.acl -- ACL setting for the S3 bucket. Possible values: `'private'|'public-read'|'public-read-write'|'authenticated-read'|'aws-exec-read'|'bucket-owner-read'|'bucket-owner-full-control'`
-    acl: *S3AclSetting   
-    # ckan.s3filestore.addressingStyle -- An optional setting to specify which addressing style to use. This controls whether the bucket name is in the hostname or is part of the URL. Accepted values are `auto` (default), `path` or `virtual`.
-    addressingStyle: *S3AddressingStyle   
-    # filesystemDownloadFallback: "false"
   psql:
     # ckan.psql.initialize -- Flag whether to initialize the PostgreSQL instance with the provided users and databases
     initialize: true
@@ -158,6 +119,8 @@ ckan:
     default: "en"
   # ckan.datapusherUrl -- Location of the datapusher service to be used by the CKAN instance
   datapusherUrl: "http://datapusher-headless:8000"
+  # ckan.datapusherCallbackUrlBase -- Location of the CKAN k8s service to be used by the Datapusher, overriding the default site url route.
+  datapusherCallbackUrlBase: http://ckan
   smtp:
     server: "smtpServerURLorIP:port"
     user: "smtpUser" 
@@ -257,10 +220,20 @@ datapusher:
   # datapusher.fullnameOverride -- Name override for the datapusher deployment
   fullnameOverride: *DatapusherName
   datapusher:
+    # datapusher.datapusher.maxContentSize -- Maximum size of content to be uploaded in bytes.
     maxContentLength: "102400000"
+    # datapusher.datapusher.chunkSize -- Size of chunks of the data that is being downloaded in bytes
     chunkSize: "10240000"
+    # datapusher.datapusher.insertRows -- Number of rows to take from the data and upload them as chunks to datastore
     insertRows: "50000"
+    # datapusher.datapusher.downloadTimeout -- Timeout limit of the download request
     downloadTimeout: "300"
+    # datapusher.datapusher.datapusherSslVerify -- Enable or disable (boolean) verification of SSL when trying to get resources. Default: True
+    datapusherSslVerify: "False"
+    # datapusher.datapusher.datapusherRewriteResources -- Enable or disable (boolean) whether datapusher should rewrite resources uploaded to CKAN's filestore, since datapusher takes the CKAN Site URL value for generating the resource URL. Default: False
+    datapusherRewriteResources: "True"
+    # datapusher.datapusher.datapusherRewriteUrl -- Sets the rewrite URL that datapushed will rewrite resources that are uploaded to CKAN's filestore. Default: http://ckan:5000
+    datapusherRewriteUrl: http://ckan
 
 redis:
   # Please see all available overrides at https://github.com/helm/charts/tree/master/stable/redis
@@ -327,29 +300,3 @@ postgresql:
   pgPass: *MasterDBPass
   # postgresql.existingSecret -- Name of existing secret that holds passwords for PostgreSQL
   existingSecret: postgrescredentials
-
-minio:
-  # minio.enabled -- Flag to control whether to deploy Minio
-  enabled: true
-  # minio.fullnameOverride -- Name override for the Minio deployment
-  fullnameOverride: minio
-  persistence:
-    # minio.persistence.size -- Size of the Minio PVC
-    size: 5Gi 
-  # minio.accessKey -- Access key for minio
-  accessKey: *S3FileStoreAccessKey
-  # minio.secretKey -- Secret key for minio
-  secretKey: *S3FileStoreSecretKey
-  defaultBucket:
-    # minio.defaultBucket.enabled -- Flag to control whether to create default bucket
-    enabled: true
-    # minio.defaultBucket.name -- Name of the default Minio bucket
-    name: *S3FileStoreBucketName
-    # minio.defaultBucket.policy -- Policy of the default Minio bucket
-    policy: upload
-  service:
-    # minio.service.type -- The service type of the Minio service
-    type: NodePort
-    # minio.service.port -- The port used by the Mino service
-    port: 9000
-

--- a/values.yaml
+++ b/values.yaml
@@ -71,6 +71,8 @@ S3FileStoreSignatureVersion: &S3FileStoreSignatureVersion "s3v4"
 S3FileStoreStoragePath: &S3FileStoreStoragePath "ckan_storage"
 # S3AclSetting -- ACL setting for the S3 bucket
 S3AclSetting: &S3AclSetting "private"
+# S3AddressingStyle -- Addresing style setting for S3
+S3AddressingStyle: &S3AddressingStyle 'path'
 
 ckan:
   # ckan.sysadminName -- CKAN system admin username
@@ -108,6 +110,8 @@ ckan:
     awsStoragePath: *S3FileStoreStoragePath 
     # ckan.s3filestore.acl -- ACL setting for the S3 bucket. Possible values: `'private'|'public-read'|'public-read-write'|'authenticated-read'|'aws-exec-read'|'bucket-owner-read'|'bucket-owner-full-control'`
     acl: *S3AclSetting   
+    # ckan.s3filestore.addressingStyle -- An optional setting to specify which addressing style to use. This controls whether the bucket name is in the hostname or is part of the URL. Accepted values are `auto` (default), `path` or `virtual`.
+    addressingStyle: *S3AddressingStyle   
     # filesystemDownloadFallback: "false"
   psql:
     # ckan.psql.initialize -- Flag whether to initialize the PostgreSQL instance with the provided users and databases
@@ -252,6 +256,11 @@ datapusher:
   enabled: true
   # datapusher.fullnameOverride -- Name override for the datapusher deployment
   fullnameOverride: *DatapusherName
+  datapusher:
+    maxContentLength: "102400000"
+    chunkSize: "10240000"
+    insertRows: "50000"
+    downloadTimeout: "300"
 
 redis:
   # Please see all available overrides at https://github.com/helm/charts/tree/master/stable/redis


### PR DESCRIPTION
* changes image tag in psqlinit and solrinit jobs to be from values fileinstead of the Chart version
* adds new datapusher envs for max size, chunk size and row quantity upload
* adds datapusher rewrite url envs following the latest updates to Datapusher
* removes s3filestore from supported ckan plugins
* removes minio as a dependency