### PR TITLE
CKAN 2.9 updates and new Helm Chart Repos

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -3,13 +3,13 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 10.5.6
 - name: solr
-  repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+  repository: https://charts.helm.sh/incubator
   version: 1.4.0
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 8.6.4
+  repository: https://charts.bitnami.com/bitnami
+  version: 10.1.1
 - name: datapusher
   repository: file://dependency-charts/datapusher
   version: 1.0.0
-digest: sha256:bf437d2c5f4da6ca447116a7c3d8b520443ba12f3528f2cca6a37b844dbfd319
-generated: "2020-09-24T15:39:58.767117823+02:00"
+digest: sha256:e0b160fabe56a5cbfd5e7a1e0e11db72f546aa8731a71d252693dddebb93759c
+generated: "2020-12-04T15:07:09.83874553+01:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -28,11 +28,11 @@ dependencies:
     condition: redis.enabled
   - name: solr
     version: 1.4.0
-    repository: "https://kubernetes-charts-incubator.storage.googleapis.com/"
+    repository: "https://charts.helm.sh/incubator"
     condition: solr.enabled
   - name: postgresql
-    version: "8.6.4"
-    repository: "https://kubernetes-charts.storage.googleapis.com/"
+    version: "10.1.1"
+    repository: "https://charts.bitnami.com/bitnami"
     condition: postgresql.enabled
   - name: datapusher
     version: "1.0.0"

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -90,12 +90,12 @@ spec:
                 secretKeyRef:
                   name: ckancredentials
                   key: ckanSqlAlchemyUrl
-            - name: CKAN__DATASTORE__WRITE_URL
+            - name: CKAN_DATASTORE_WRITE_URL
               valueFrom:
                 secretKeyRef:
                   name: ckancredentials
                   key: ckanDatastoreWriteUrl
-            - name: CKAN__DATASTORE__READ_URL
+            - name: CKAN_DATASTORE_READ_URL
               valueFrom:
                 secretKeyRef:
                   name: ckancredentials

--- a/values.yaml
+++ b/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: keitaro/ckan
-  tag: 2.8.5
+  tag: 2.9.1
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
* updates helm chart repos to the new values
* moves to CKAN 2.9 and updates datastore env variables accordingly