### PR TITLE
Ckan 2.9 - change paster commands to use the ckan cli

### DIFF
--- a/psql-init/psql-init.py
+++ b/psql-init/psql-init.py
@@ -154,14 +154,13 @@ try:
 except(Exception, psycopg2.DatabaseError) as error:
     print("ERROR DB: ", error)
 
-# replace ckan.plugins so that paster can run and apply datastore permissions
+# replace ckan.plugins so that ckan cli can run and apply datastore permissions
 sed_string = "s/ckan.plugins =.*/ckan.plugins = envvars image_view text_view recline_view datastore/g" # noqa
 subprocess.Popen(["/bin/sed", sed_string, "-i", "/srv/app/production.ini"])
-sql = subprocess.check_output(["/usr/bin/paster",
-                               "--plugin=ckan",
+sql = subprocess.check_output(["/usr/bin/ckan",
+                               "-c", "/srv/app/production.ini",
                                "datastore",
-                               "set-permissions",
-                               "-c", "/srv/app/production.ini"],
+                               "set-permissions"],
                               stderr=subprocess.PIPE)
 # Remove the connect clause from the output
 sql = re.sub("\\\connect.*", "", sql)

--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -16,12 +16,11 @@ spec:
               {{- toYaml .Values.securityContext | nindent 14 }}
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
-            command: ["paster"]
+            command: ["ckan"]
             args:
-            - --plugin=ckan
-            - post
             - -c
             - /srv/app/production.ini
+            - post
             - /api/action/send_email_notifications
             env:
 {{- if .Values.ckan.extraEnv }}


### PR DESCRIPTION
Changing paster commands to use the `ckan` CLI so that we are 2.9 compatible. We will change the Keitaro CKAN docker images for 2.8 and 2.7 to have an alias command `ckan` so that the helm chart will work fine for all supported CKAN versions.