### PR TITLE
Use a sysadmin API token to trigger sending of email notifications

### DIFF
--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -19,3 +19,5 @@
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 5000:5000
   echo "Visit http://127.0.0.1:5000 to use CKAN"
 {{- end }}
+2. Generate an API Token for the sysadmin user using the CKAN UI, replace it in your values file and replace the secret with the new value at runtime
+  kubectl -n {namespace} create secret generic ckansysadminapitoken --from-literal=sysadminApiToken={insert_generated_api_token_here} --dry-run -o yaml | kubectl apply -f -

--- a/templates/ckansysadminapitoken.yaml
+++ b/templates/ckansysadminapitoken.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ckansysadminapitoken
+type: Opaque
+stringData:
+  sysadminApiToken: {{ .Values.ckan.sysadminApiToken }}

--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -16,12 +16,14 @@ spec:
               {{- toYaml .Values.securityContext | nindent 14 }}
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
-            command: ["ckan"]
+            command: ["curl"]
             args:
-            - -c
-            - /srv/app/production.ini
-            - post
-            - /api/action/send_email_notifications
+            - -s
+            - -H 
+            - "Authorization: $(CKAN_SYSADMIN_API_TOKEN)"
+            - -d
+            - "{}"
+            - "http://ckan/api/action/send_email_notifications"
             env:
 {{- if .Values.ckan.extraEnv }}
 {{ toYaml .Values.ckan.extraEnv | indent 12 }}
@@ -36,6 +38,11 @@ spec:
               value: {{ .Values.ckan.ckanPlugins }}
             - name: CKAN__STORAGE_PATH
               value: {{ .Values.ckan.storagePath }}
+            - name: CKAN_SYSADMIN_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: ckansysadminapitoken
+                  key: sysadminApiToken
             - name: CKAN_SQLALCHEMY_URL
               valueFrom:
                 secretKeyRef:

--- a/values.yaml
+++ b/values.yaml
@@ -60,6 +60,9 @@ ckan:
   sysadminName: "ckan_admin"
   # ckan.sysadminPassword -- CKAN system admin password
   sysadminPassword: "PasswordHere"
+  # ckan.sysadminApiToken -- CKAN system admin API token
+  # Needs to be generated via the CKAN UI and replaced after initial deployment
+  sysadminApiToken: "replace_this_with_generated_api_token_for_sysadmin"
   # ckan.sysadminEmail -- CKAN system admin email
   sysadminEmail: "admin@domain.com"
   # ckan.siteTitle -- Site title for the instance


### PR DESCRIPTION
Due to `paster post` equivalent not being available in CKAN 2.9, we use a generated sysadmin API token and `curl` to call the api endpoint for triggering the sending of email notifications