### PR TITLE
Add imagePullSecrets for psql-init and solr-init and show psql errors

### DIFF
--- a/psql-init/psql-init.py
+++ b/psql-init/psql-init.py
@@ -214,11 +214,10 @@ except(Exception, psycopg2.DatabaseError) as error:
 # replace ckan.plugins so that ckan cli can run and apply datastore permissions
 sed_string = "s/ckan.plugins =.*/ckan.plugins = envvars image_view text_view recline_view datastore/g"  # noqa
 subprocess.Popen(["/bin/sed", sed_string, "-i", "/srv/app/production.ini"])
-sql = subprocess.check_output(["ckan",
-                               "-c", "/srv/app/production.ini",
-                               "datastore",
-                               "set-permissions"],
-                              stderr=subprocess.PIPE)
+try:
+    sql = subprocess.check_output(["ckan","-c", "/srv/app/production.ini","datastore","set-permissions"],stderr=subprocess.STDOUT)
+except subprocess.CalledProcessError as e:
+    raise RuntimeError("command '{}' return with error (code {}): {}".format(e.cmd, e.returncode, e.output))
 sql = sql.decode('utf-8')
 sql = sql.replace("@"+datastorerw_db.db_host, "")
 

--- a/templates/psql-init-job.yaml
+++ b/templates/psql-init-job.yaml
@@ -6,6 +6,10 @@ metadata:
 spec:
   template:
     spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       volumes:
         - name: psql-init-configmap
           configMap:

--- a/templates/solr-init-job.yaml
+++ b/templates/solr-init-job.yaml
@@ -6,6 +6,10 @@ metadata:
 spec:
   template:
     spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       volumes:
         - name: solr-init-configmap
           configMap:


### PR DESCRIPTION
If we use imagePullSecrets, psql-init and solr-init will not pull the images because imagePullSecrets is only defined for the main CKAN container.
This pull reguest fixes this bug and adds imagePullSecrets for all containers.

Also adds a slight modification to psql-init.py to show specific errors when there are problems communicating with PostgreSQL.