### PR TITLE
Add custom values to ckan deployment

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "ckan-chart.fullname" . }}
   labels:
     {{- include "ckan-chart.labels" . | nindent 4 }}
+    {{- index .Values "ckan-labels" | toYaml | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "ckan-chart.fullname" . }}
   labels:
     {{- include "ckan-chart.labels" . | nindent 4 }}
-    {{- index .Values "ckan-labels" | toYaml | nindent 4 }}
+    {{- .Values.labes.ckan | toYaml | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/values.yaml
+++ b/values.yaml
@@ -4,9 +4,6 @@
 
 replicaCount: 1
 
-ckan-labels:
-  label1: value1
-
 image:
   repository: keitaro/ckan
   tag: 2.9.4
@@ -151,6 +148,13 @@ ckan:
   #     value: "bar"
   #
   extraEnv: []
+
+  # labels.ckan -- A map where you can add extra labels to the ckan deployment:
+  # example:
+  # ckan:
+  #   test: label1
+  labels:
+    ckan: []
 
   readiness:
     # ckan.readiness.initialDelaySeconds -- Inital delay seconds for the readiness probe

--- a/values.yaml
+++ b/values.yaml
@@ -4,6 +4,9 @@
 
 replicaCount: 1
 
+ckan-labels:
+  label1: value1
+
 image:
   repository: keitaro/ckan
   tag: 2.9.4


### PR DESCRIPTION
The feature can be used to implement custom labels in the ckan deployment through the values file.