### PR TITLE
Update ingress.yaml

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "ckan-chart.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 {{- else -}}
 apiVersion: extensions/v1beta1
 {{- end }}


### PR DESCRIPTION
problem: when running terraform deployment for helm_release i get this error
Error: resource mapping not found for name: "ckan" namespace: "" from "": no matches for kind "Ingress" in version "networking.k8s.io/v1beta1" 

update ingress api version, since betav1 got removed
https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122
