### PR TITLE
create pipeline on tag push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,8 @@
 name: Upload Helm chart to GCS bucket
 on:
-  create:
+  push:
+    tags:
+      - "*"
 jobs:
   release:
     if: ${{ startsWith(github.ref, 'refs/tags/') }}


### PR DESCRIPTION
Changing the pipeline creation for the helm chart to execute only on push for tags