### PR TITLE
Update Chart dependencies to bitnami latest

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: redis
-  repository: https://keitaro-charts.storage.googleapis.com
-  version: 16.5.5
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 18.12.1
 - name: solr
-  repository: https://keitaro-charts.storage.googleapis.com
-  version: 4.1.2
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 8.7.1
 - name: postgresql
-  repository: https://keitaro-charts.storage.googleapis.com
-  version: 10.16.2
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 14.0.1
 - name: datapusher
   repository: https://keitaro-charts.storage.googleapis.com
   version: 1.0.0
-digest: sha256:0d4d71c90a5292036a1c351b3e042f6130e76193edb9519ce09adc0e3a828069
-generated: "2023-06-22T14:49:19.198522804+02:00"
+digest: sha256:818e5030fa102128181648b063bf903af4c47a8e7bae01e347e6895ee5526b0e
+generated: "2024-02-05T10:04:18.721507254+01:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -24,16 +24,16 @@ appVersion: 2.10.3
 # Dependencies
 dependencies:
   - name: redis 
-    version: 16.5.5
-    repository: "https://keitaro-charts.storage.googleapis.com"
+    version: 18.12.1
+    repository: oci://registry-1.docker.io/bitnamicharts
     condition: redis.enabled
   - name: solr
-    version: 4.1.2
-    repository: "https://keitaro-charts.storage.googleapis.com"
+    version: 8.7.1
+    repository:  oci://registry-1.docker.io/bitnamicharts
     condition: solr.enabled
   - name: postgresql
-    version: 10.16.2
-    repository: "https://keitaro-charts.storage.googleapis.com"
+    version: 14.0.1
+    repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled
   # - name: datapusher-plus
   #   version: 1.0.0

--- a/values.yaml
+++ b/values.yaml
@@ -312,6 +312,10 @@ solr:
   # Please see all available overrides at https://github.com/bitnami/charts/tree/master/bitnami/solr/#installing-the-chart
   # solr.enabled -- Flag to control whether to deploy SOLR
   enabled: true
+  global:
+    imageRegistry: ""
+    imagePullSecrets: []
+    storageClass: ""
   auth:
   # solr.auth.enabled -- Enable or disable auth (if auth is disabled solr-init cant upload the configset/schema.xml for ckan)
     enabled: true
@@ -367,10 +371,22 @@ postgresql:
     size: 1Gi
   # postgresql.fullnameOverride -- Name override for the PostgreSQL deployment
   fullnameOverride: *DBDeploymentName
-  # postgresql.pgPass -- Password for the master PostgreSQL user.
-  # Feeds into the `postgrescredentials` secret that is provided to the PostgreSQL chart
-  pgPass: *MasterDBPass
-  # postgresql.existingSecret -- Name of existing secret that holds passwords for PostgreSQL
-  existingSecret: postgrescredentials
-  
+  # @param postgresql.auth.postgresPassword Password for the "postgres" admin user (overrides `auth.postgresPassword`)
+  # @param postgresql.auth.username Name for a custom user to create (overrides `auth.username`)
+  # @param postgresql.auth.password Password for the custom user to create (overrides `auth.password`)
+  # @param postgresql.auth.database Name for a custom database to create (overrides `auth.database`)
+  # @param postgresql.auth.existingSecret Name of existing secret to use for PostgreSQL credentials (overrides `auth.existingSecret`).
+  # @param postgresql.auth.secretKeys.adminPasswordKey Name of key in existing secret to use for PostgreSQL credentials (overrides `auth.secretKeys.adminPasswordKey`). Only used when `global.postgresql.auth.existingSecret` is set.
+  # @param postgresql.auth.secretKeys.userPasswordKey Name of key in existing secret to use for PostgreSQL credentials (overrides `auth.secretKeys.userPasswordKey`). Only used when `global.postgresql.auth.existingSecret` is set.
+  # @param postgresql.auth.secretKeys.replicationPasswordKey Name of key in existing secret to use for PostgreSQL credentials (overrides `auth.secretKeys.replicationPasswordKey`). Only used when `global.postgresql.auth.existingSecret` is set.
+  auth:
+    postgresPassword: *MasterDBPass
+    username: *CkanDBUser
+    password: *CkanDBPass
+    database: *CkanDBName
+    # existingSecret: ""
+    # secretKeys:
+    #   adminPasswordKey: ""
+    #   userPasswordKey: ""
+    #   replicationPasswordKey: ""
   


### PR DESCRIPTION
Please validate if the new charts still match your requirements, for a new deployment everything works, but i Cannot test this for existing deployments

Updated dependency charts to the latest available bitnami charts to fix issues and vulnarabilities

Fixed: https://github.com/keitaroinc/ckan-helm/issues/111

Updated:
  - redis: 18.12.1 (https://bitnami.com/stack/redis/helm)
  - solr: 8.7.1 (https://bitnami.com/stack/solr/helm)
  - postgresql: 14.0.1 (https://bitnami.com/stack/postgresql/helm)

Changed values.yaml to match the required postgres username and password to be initialized

