### PR TITLE
Add missing helm dep up command

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -66,6 +66,9 @@ jobs:
         with:
           python-version: 3.8
 
+      - name: Pull Helm dependencies
+        run: helm dependency update
+
       - name: Run Trivy vulnerability scanner in IaC mode
         uses: aquasecurity/trivy-action@0.33.1
         with:


### PR DESCRIPTION
This PR updates the Trivy GitHub Actions workflow:

*   Added a `helm dependency update` step to ensure all Helm chart dependencies are pulled before IaC scanning.
