### PR TITLE
Add OpenShift compatibility support

### DIFF
--- a/.github/workflows/build-custom-ckan-image.yaml
+++ b/.github/workflows/build-custom-ckan-image.yaml
@@ -65,8 +65,8 @@ jobs:
             type=ref,event=branch
             # Tag with PR number
             type=ref,event=pr
-            # Tag with git sha (short)
-            type=sha,prefix={{branch}}-
+            # Tag with git sha (short) - only for branch pushes, not tags
+            type=sha,prefix={{branch}}-,enable=${{ github.event_name != 'push' || !startsWith(github.ref, 'refs/tags/') }}
             # Tag as latest on master/main or git tag
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') || github.ref == format('refs/heads/{0}', 'main') || startsWith(github.ref, 'refs/tags/') }}
           labels: |

--- a/.github/workflows/build-custom-ckan-image.yaml
+++ b/.github/workflows/build-custom-ckan-image.yaml
@@ -1,0 +1,135 @@
+name: Build and Push Custom CKAN Image
+
+on:
+  push:
+    branches:
+      - master
+      - main
+    paths:
+      - 'Dockerfile.custom'
+      - 'schemas/**'
+      - '.github/workflows/build-custom-ckan-image.yaml'
+  pull_request:
+    branches:
+      - master
+      - main
+    paths:
+      - 'Dockerfile.custom'
+      - 'schemas/**'
+  workflow_dispatch:
+    inputs:
+      tag_suffix:
+        description: 'Additional tag suffix (e.g., -test, -beta)'
+        required: false
+        default: ''
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/ckan-custom
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # Tag with branch name
+            type=ref,event=branch
+            # Tag with PR number
+            type=ref,event=pr
+            # Tag with git sha (short)
+            type=sha,prefix={{branch}}-
+            # Tag as latest on master/main
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') || github.ref == format('refs/heads/{0}', 'main') }}
+            # Semantic version tags from Dockerfile
+            type=raw,value=2.11.4-scheming3.1-dcat2.4,enable=${{ github.ref == format('refs/heads/{0}', 'master') || github.ref == format('refs/heads/{0}', 'main') }}
+          labels: |
+            org.opencontainers.image.title=CKAN Custom (Scheming + DCAT)
+            org.opencontainers.image.description=Custom CKAN 2.11.4 image with scheming and DCAT extensions
+            org.opencontainers.image.vendor=Stad Gent
+            org.opencontainers.image.licenses=AGPL-3.0
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.custom
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64
+
+      - name: Generate build summary
+        if: success()
+        run: |
+          echo "## 🚀 Docker Image Built Successfully" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Image Details" >> $GITHUB_STEP_SUMMARY
+          echo "- **Registry**: \`${{ env.REGISTRY }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Image**: \`${{ env.IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Tags**: " >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Extensions Included" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ ckanext-scheming 3.1.0" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ ckanext-dcat 2.4.2" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ rdflib 7.0.0" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Pull Command" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+
+      - name: Create deployment comment
+        if: github.event_name == 'pull_request' && success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `## 🐳 Docker Image Preview Built
+
+              The custom CKAN image has been built for this PR and is available for testing.
+
+              **Image**: \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}\`
+
+              ### To test this image:
+              \`\`\`bash
+              # Update values-openshift.yaml
+              image:
+                repository: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+                tag: pr-${{ github.event.pull_request.number }}
+
+              # Deploy to test environment
+              helm upgrade ckan . -f values-openshift.yaml -n d09-open-data-qa
+              \`\`\`
+
+              **Note**: This is a preview image and will not be pushed to the registry on PR builds.`
+            })

--- a/.github/workflows/build-custom-ckan-image.yaml
+++ b/.github/workflows/build-custom-ckan-image.yaml
@@ -6,7 +6,7 @@ on:
       - master
       - main
     paths:
-      - 'Dockerfile.custom'
+      - 'Dockerfile'
       - 'schemas/**'
       - '.github/workflows/build-custom-ckan-image.yaml'
   pull_request:
@@ -14,7 +14,7 @@ on:
       - master
       - main
     paths:
-      - 'Dockerfile.custom'
+      - 'Dockerfile'
       - 'schemas/**'
   workflow_dispatch:
     inputs:

--- a/.github/workflows/build-custom-ckan-image.yaml
+++ b/.github/workflows/build-custom-ckan-image.yaml
@@ -9,6 +9,9 @@ on:
       - 'Dockerfile'
       - 'schemas/**'
       - '.github/workflows/build-custom-ckan-image.yaml'
+    tags:
+      - 'v*.*.*'
+      - '*.*.*'
   pull_request:
     branches:
       - master
@@ -54,19 +57,21 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
+            # Semantic versioning from git tags
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
             # Tag with branch name
             type=ref,event=branch
             # Tag with PR number
             type=ref,event=pr
             # Tag with git sha (short)
             type=sha,prefix={{branch}}-
-            # Tag as latest on master/main
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') || github.ref == format('refs/heads/{0}', 'main') }}
-            # Semantic version tags from Dockerfile
-            type=raw,value=2.11.4-scheming3.1-dcat2.4,enable=${{ github.ref == format('refs/heads/{0}', 'master') || github.ref == format('refs/heads/{0}', 'main') }}
+            # Tag as latest on master/main or git tag
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') || github.ref == format('refs/heads/{0}', 'main') || startsWith(github.ref, 'refs/tags/') }}
           labels: |
-            org.opencontainers.image.title=CKAN Custom (Scheming + DCAT)
-            org.opencontainers.image.description=Custom CKAN 2.11.4 image with scheming and DCAT extensions
+            org.opencontainers.image.title=CKAN Custom (Scheming + Harvest + DCAT)
+            org.opencontainers.image.description=Custom CKAN 2.11.4 image with scheming, harvest, and DCAT extensions (euro_dcat_ap_3)
             org.opencontainers.image.vendor=Stad Gent
             org.opencontainers.image.licenses=AGPL-3.0
 

--- a/.github/workflows/build-custom-ckan-image.yaml
+++ b/.github/workflows/build-custom-ckan-image.yaml
@@ -74,7 +74,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ./Dockerfile.custom
+          file: ./Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+############
+### MAIN ###
+############
+FROM ghcr.io/keitaroinc/ckan:2.11.2
+
+# CKAN extension source code URLs
+#ENV ACME_GIT_URL="https://github.com/myghorg/ckanext-acme.git"
+#ENV ACME_GIT_VERSION="0.4.2"
+#ENV ACME_REQUIREMENTS_URL="https://raw.githubusercontent.com/myghorg/ckanext-acme/refs/tags/${ACME_GIT_VERSION}/requirements.txt"
+
+### Scheming ###
+ENV SCHEMING_GIT_URL="https://github.com/ckan/ckanext-scheming.git"
+ENV SCHEMING_GIT_VERSION="release-3.1.0"
+
+### Harvest (required by dcat_rdf_harvester) ###
+ENV HARVEST_GIT_URL="https://github.com/ckan/ckanext-harvest.git"
+ENV HARVEST_GIT_VERSION="v1.6.2"
+ENV HARVEST_REQUIREMENTS_URL="https://raw.githubusercontent.com/ckan/ckanext-harvest/refs/tags/${HARVEST_GIT_VERSION}/requirements.txt"
+
+### DCAT ###
+ENV DCAT_GIT_URL="https://github.com/ckan/ckanext-dcat.git"
+ENV DCAT_GIT_VERSION="v2.4.2"
+ENV DCAT_REQUIREMENTS_URL="https://raw.githubusercontent.com/ckan/ckanext-dcat/refs/tags/${DCAT_GIT_VERSION}/requirements.txt"
+
+### Pages ###
+#ENV PAGES_GIT_URL="https://github.com/ckan/ckanext-pages.git"
+#ENV PAGES_GIT_VERSION="master"
+
+# Add the custom extensions to the plugins list
+ENV CKAN__PLUGINS="envvars activity image_view text_view datatables_view datastore xloader scheming_datasets harvest dcat dcat_rdf_harvester structured_data"
+
+# Switch to the root user
+USER root
+
+# Install and enable the custom extensions
+    # Install necessary system packages with apk 
+RUN apk add --no-cache libffi-dev && \
+    # Install the CKAN extension and any requirements using uv
+    uv pip install --system git+${SCHEMING_GIT_URL}@${SCHEMING_GIT_VERSION} && \
+    uv pip install --system git+${HARVEST_GIT_URL}@${HARVEST_GIT_VERSION} && \
+    uv pip install --system -r ${HARVEST_REQUIREMENTS_URL} && \
+    uv pip install --system git+${DCAT_GIT_URL}@${DCAT_GIT_VERSION} && \
+    # Install any other required python packages
+    uv pip install --system requests && \
+    # Update plugin configuration
+    ckan config-tool ${APP_DIR}/production.ini "ckan.plugins = ${CKAN__PLUGINS}" && \
+    ckan config-tool ${APP_DIR}/production.ini "scheming.dataset_schemas = ckanext.dcat.schemas:dcat_ap_full.yaml" && \
+    ckan config-tool ${APP_DIR}/production.ini "scheming.presets = ckanext.scheming:presets.json ckanext.dcat.schemas:presets.yaml" && \
+    ckan config-tool ${APP_DIR}/production.ini "ckanext.dcat.rdf.profiles = euro_dcat_ap_3" && \
+    chown -R ckan:ckan /app && \
+    # Remove uv cache
+    rm -rf /app/cache
+
+# Switch to the ckan user
+USER ckan

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ENV DCAT_REQUIREMENTS_URL="https://raw.githubusercontent.com/ckan/ckanext-dcat/r
 #ENV PAGES_GIT_VERSION="master"
 
 # Add the custom extensions to the plugins list
-ENV CKAN__PLUGINS="envvars activity image_view text_view datatables_view datastore xloader scheming_datasets harvest dcat dcat_rdf_harvester structured_data"
+ENV CKAN__PLUGINS="envvars activity image_view text_view datatables_view datastore xloader scheming_datasets harvest dcat dcat_rdf_harvester structured_data stadgent_validators"
 
 # Switch to the root user
 USER root
@@ -56,6 +56,11 @@ RUN apk add --no-cache libffi-dev && \
 
 # Copy custom Stad Gent DCAT schema
 COPY --chown=ckan:ckan schemas/dcat_ap_stadgent.yaml ${APP_DIR}/schemas/
+
+# Copy and install custom validators extension
+COPY validators/ckanext-stadgent-validators /tmp/ckanext-stadgent-validators
+RUN uv pip install --system /tmp/ckanext-stadgent-validators && \
+    rm -rf /tmp/ckanext-stadgent-validators
 
 # Switch to the ckan user
 USER ckan

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ ENV DCAT_REQUIREMENTS_URL="https://raw.githubusercontent.com/ckan/ckanext-dcat/r
 #ENV PAGES_GIT_VERSION="master"
 
 # Add the custom extensions to the plugins list
-ENV CKAN__PLUGINS="envvars activity image_view text_view datatables_view datastore xloader scheming_datasets harvest dcat dcat_rdf_harvester structured_data stadgent_validators"
+# Note: stadgent_validators disabled temporarily (will be enabled in future version)
+ENV CKAN__PLUGINS="envvars activity image_view text_view datatables_view datastore xloader scheming_datasets harvest dcat dcat_rdf_harvester structured_data"
 
 # Switch to the root user
 USER root
@@ -57,10 +58,10 @@ RUN apk add --no-cache libffi-dev && \
 # Copy custom Stad Gent DCAT schema
 COPY --chown=ckan:ckan schemas/dcat_ap_stadgent.yaml ${APP_DIR}/schemas/
 
-# Copy and install custom validators extension
-COPY validators/ckanext-stadgent-validators /tmp/ckanext-stadgent-validators
-RUN uv pip install --system /tmp/ckanext-stadgent-validators && \
-    rm -rf /tmp/ckanext-stadgent-validators
+# Copy and install custom validators extension (disabled for now)
+# COPY validators/ckanext-stadgent-validators /tmp/ckanext-stadgent-validators
+# RUN uv pip install --system /tmp/ckanext-stadgent-validators && \
+#     rm -rf /tmp/ckanext-stadgent-validators
 
 # Switch to the ckan user
 USER ckan

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,14 +42,20 @@ RUN apk add --no-cache libffi-dev && \
     uv pip install --system git+${DCAT_GIT_URL}@${DCAT_GIT_VERSION} && \
     # Install any other required python packages
     uv pip install --system requests && \
+    # Create schemas directory
+    mkdir -p ${APP_DIR}/schemas && \
+    chown -R ckan:ckan ${APP_DIR}/schemas && \
     # Update plugin configuration
     ckan config-tool ${APP_DIR}/production.ini "ckan.plugins = ${CKAN__PLUGINS}" && \
-    ckan config-tool ${APP_DIR}/production.ini "scheming.dataset_schemas = ckanext.dcat.schemas:dcat_ap_full.yaml" && \
+    ckan config-tool ${APP_DIR}/production.ini "scheming.dataset_schemas = file://${APP_DIR}/schemas/dcat_ap_stadgent.yaml" && \
     ckan config-tool ${APP_DIR}/production.ini "scheming.presets = ckanext.scheming:presets.json ckanext.dcat.schemas:presets.yaml" && \
     ckan config-tool ${APP_DIR}/production.ini "ckanext.dcat.rdf.profiles = euro_dcat_ap_3" && \
     chown -R ckan:ckan /app && \
     # Remove uv cache
     rm -rf /app/cache
+
+# Copy custom Stad Gent DCAT schema
+COPY --chown=ckan:ckan schemas/dcat_ap_stadgent.yaml ${APP_DIR}/schemas/
 
 # Switch to the ckan user
 USER ckan

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ############
 ### MAIN ###
 ############
-FROM ghcr.io/keitaroinc/ckan:2.11.2
+FROM ghcr.io/keitaroinc/ckan:2.11.4
 
 # CKAN extension source code URLs
 #ENV ACME_GIT_URL="https://github.com/myghorg/ckanext-acme.git"

--- a/Dockerfile.custom
+++ b/Dockerfile.custom
@@ -1,0 +1,40 @@
+# Custom CKAN image with scheming and DCAT extensions
+# Based on keitaro/ckan:2.11.4
+
+FROM keitaro/ckan:2.11.4
+
+# Extension versions
+ENV SCHEMING_VERSION="3.1.0"
+ENV DCAT_VERSION="2.4.2"
+ENV RDFLIB_VERSION="7.0.0"
+
+# Plugin configuration - keep all base plugins and add new ones
+ENV CKAN__PLUGINS="envvars activity image_view text_view datatables_view datastore xloader scheming_datasets dcat dcat_json_interface structured_data"
+
+# Switch to root user for installation
+USER root
+
+# Install extensions using uv (faster and more reliable than pip)
+RUN uv pip install --system \
+    ckanext-scheming==${SCHEMING_VERSION} \
+    ckanext-dcat==${DCAT_VERSION} \
+    rdflib==${RDFLIB_VERSION} && \
+    # Create directory for custom schemas
+    mkdir -p /app/schemas && \
+    chown -R ckan:ckan /app/schemas && \
+    # Update plugin configuration in production.ini
+    ckan config-tool ${APP_DIR}/production.ini "ckan.plugins = ${CKAN__PLUGINS}" && \
+    # Clean up uv cache to reduce image size
+    rm -rf /root/.cache/uv
+
+# Copy custom scheming schema
+COPY --chown=ckan:ckan schemas/dataset_schema.yaml /app/schemas/
+
+# Switch back to ckan user
+USER ckan
+
+# Metadata labels
+LABEL description="CKAN 2.11.4 with scheming ${SCHEMING_VERSION} and DCAT ${DCAT_VERSION}"
+LABEL extensions="ckanext-scheming==${SCHEMING_VERSION} ckanext-dcat==${DCAT_VERSION}"
+LABEL maintainer="Stad Gent"
+LABEL org.opencontainers.image.source="https://github.com/MPParsley/ckan-helm"

--- a/Dockerfile.custom
+++ b/Dockerfile.custom
@@ -27,7 +27,8 @@ RUN uv pip install --system \
     # Add scheming and DCAT configuration directly to production.ini
     echo "" >> /app/production.ini && \
     echo "## Scheming Configuration" >> /app/production.ini && \
-    echo "scheming.dataset_schemas = /app/schemas/dataset_schema.yaml" >> /app/production.ini && \
+    echo "# Use DCAT-AP recommended schema (pre-built, compatible with DCAT)" >> /app/production.ini && \
+    echo "scheming.dataset_schemas = ckanext.dcat.schemas:dcat_ap_recommended.yaml" >> /app/production.ini && \
     echo "scheming.presets = ckanext.scheming:presets.json ckanext.dcat.schemas:presets.yaml" >> /app/production.ini && \
     echo "scheming.organization_schemas = ckanext.scheming:organization.json" >> /app/production.ini && \
     echo "scheming.group_schemas = ckanext.scheming:group.json" >> /app/production.ini && \

--- a/Dockerfile.custom
+++ b/Dockerfile.custom
@@ -1,40 +1,29 @@
-# Custom CKAN image with scheming and DCAT extensions
+# Custom CKAN image with DCAT extension
 # Based on keitaro/ckan:2.11.4
 
 FROM keitaro/ckan:2.11.4
 
 # Extension versions
-ENV SCHEMING_VERSION="3.1.0"
 ENV DCAT_VERSION="2.4.2"
 ENV RDFLIB_VERSION="7.0.0"
 
-# Plugin configuration - keep all base plugins and add new ones
-ENV CKAN__PLUGINS="envvars activity image_view text_view datatables_view datastore xloader scheming_datasets dcat dcat_json_interface structured_data"
+# Plugin configuration - keep all base plugins and add DCAT
+ENV CKAN__PLUGINS="envvars activity image_view text_view datatables_view datastore xloader dcat dcat_json_interface structured_data"
 
 # Switch to root user for installation
 USER root
 
-# Install extensions using uv (faster and more reliable than pip)
+# Install DCAT extension using uv (faster and more reliable than pip)
 RUN uv pip install --system \
-    ckanext-scheming==${SCHEMING_VERSION} \
     ckanext-dcat==${DCAT_VERSION} \
     rdflib==${RDFLIB_VERSION} && \
-    # Create directory for custom schemas
-    mkdir -p /app/schemas && \
-    chown -R ckan:ckan /app/schemas && \
     # Update plugin configuration in production.ini using sed
     sed -i 's/^ckan.plugins =.*/ckan.plugins = '"${CKAN__PLUGINS}"'/' /app/production.ini && \
-    # Add scheming and DCAT configuration directly to production.ini
-    echo "" >> /app/production.ini && \
-    echo "## Scheming Configuration" >> /app/production.ini && \
-    echo "# Use DCAT-AP recommended schema (pre-built, compatible with DCAT)" >> /app/production.ini && \
-    echo "scheming.dataset_schemas = ckanext.dcat.schemas:dcat_ap_recommended.yaml" >> /app/production.ini && \
-    echo "scheming.presets = ckanext.scheming:presets.json ckanext.dcat.schemas:presets.yaml" >> /app/production.ini && \
-    echo "scheming.organization_schemas = ckanext.scheming:organization.json" >> /app/production.ini && \
-    echo "scheming.group_schemas = ckanext.scheming:group.json" >> /app/production.ini && \
+    # Add DCAT configuration directly to production.ini
     echo "" >> /app/production.ini && \
     echo "## DCAT Configuration" >> /app/production.ini && \
-    echo "ckanext.dcat.rdf.profiles = euro_dcat_ap_2 euro_dcat_ap" >> /app/production.ini && \
+    echo "# Using euro_dcat_ap_3 profile (latest European DCAT-AP specification)" >> /app/production.ini && \
+    echo "ckanext.dcat.rdf.profiles = euro_dcat_ap_3 euro_dcat_ap_2 euro_dcat_ap" >> /app/production.ini && \
     echo "ckanext.dcat.translate_keys = true" >> /app/production.ini && \
     echo "ckanext.dcat.enable_rdf_endpoints = true" >> /app/production.ini && \
     echo "ckanext.dcat.enable_content_negotiation = true" >> /app/production.ini && \
@@ -42,14 +31,11 @@ RUN uv pip install --system \
     # Clean up uv cache to reduce image size
     rm -rf /root/.cache/uv
 
-# Copy custom scheming schema
-COPY --chown=ckan:ckan schemas/dataset_schema.yaml /app/schemas/
-
 # Switch back to ckan user
 USER ckan
 
 # Metadata labels
-LABEL description="CKAN 2.11.4 with scheming ${SCHEMING_VERSION} and DCAT ${DCAT_VERSION}"
-LABEL extensions="ckanext-scheming==${SCHEMING_VERSION} ckanext-dcat==${DCAT_VERSION}"
+LABEL description="CKAN 2.11.4 with DCAT ${DCAT_VERSION} and euro_dcat_ap_3 profile"
+LABEL extensions="ckanext-dcat==${DCAT_VERSION}"
 LABEL maintainer="Stad Gent"
 LABEL org.opencontainers.image.source="https://github.com/MPParsley/ckan-helm"

--- a/Dockerfile.custom
+++ b/Dockerfile.custom
@@ -4,17 +4,19 @@
 FROM keitaro/ckan:2.11.4
 
 # Extension versions
+ENV SCHEMING_VERSION="3.1.0"
 ENV DCAT_VERSION="2.4.2"
 ENV RDFLIB_VERSION="7.0.0"
 
-# Plugin configuration - keep all base plugins and add DCAT
-ENV CKAN__PLUGINS="envvars activity image_view text_view datatables_view datastore xloader dcat dcat_json_interface structured_data"
+# Plugin configuration - keep all base plugins and add DCAT (as per docs)
+ENV CKAN__PLUGINS="envvars activity image_view text_view datatables_view datastore xloader dcat dcat_rdf_harvester structured_data"
 
 # Switch to root user for installation
 USER root
 
-# Install DCAT extension using uv (faster and more reliable than pip)
+# Install scheming (required by structured_data) and DCAT extension using uv
 RUN uv pip install --system \
+    ckanext-scheming==${SCHEMING_VERSION} \
     ckanext-dcat==${DCAT_VERSION} \
     rdflib==${RDFLIB_VERSION} && \
     # Update plugin configuration in production.ini using sed
@@ -35,7 +37,7 @@ RUN uv pip install --system \
 USER ckan
 
 # Metadata labels
-LABEL description="CKAN 2.11.4 with DCAT ${DCAT_VERSION} and euro_dcat_ap_3 profile"
-LABEL extensions="ckanext-dcat==${DCAT_VERSION}"
+LABEL description="CKAN 2.11.4 with DCAT ${DCAT_VERSION} (euro_dcat_ap_3) and scheming ${SCHEMING_VERSION}"
+LABEL extensions="ckanext-scheming==${SCHEMING_VERSION} ckanext-dcat==${DCAT_VERSION}"
 LABEL maintainer="Stad Gent"
 LABEL org.opencontainers.image.source="https://github.com/MPParsley/ckan-helm"

--- a/Dockerfile.custom
+++ b/Dockerfile.custom
@@ -4,22 +4,25 @@
 FROM keitaro/ckan:2.11.4
 
 # Extension versions
-ENV SCHEMING_VERSION="3.1.0"
-ENV DCAT_VERSION="2.4.2"
-ENV RDFLIB_VERSION="7.0.0"
+ENV SCHEMING_VERSION="release-3.1.0"
+ENV HARVEST_VERSION="v1.5.6"
+ENV DCAT_VERSION="v2.4.2"
 
-# Plugin configuration - keep all base plugins and add DCAT (as per docs)
+# Plugin configuration - keep all base plugins and add DCAT
+# dcat: core DCAT RDF export functionality
+# dcat_rdf_harvester: harvest DCAT datasets from other catalogs
+# structured_data: schema.org/DCAT-AP JSON-LD in dataset pages
 ENV CKAN__PLUGINS="envvars activity image_view text_view datatables_view datastore xloader dcat dcat_rdf_harvester structured_data"
 
 # Switch to root user for installation
 USER root
 
-# Install scheming (required by structured_data) and DCAT extension using uv
-RUN uv pip install --system \
-    ckanext-scheming==${SCHEMING_VERSION} \
-    ckanext-dcat==${DCAT_VERSION} \
-    rdflib==${RDFLIB_VERSION} && \
-    # Update plugin configuration in production.ini using sed
+# Install extensions using uv
+RUN uv pip install --system git+https://github.com/ckan/ckanext-scheming.git@${SCHEMING_VERSION} && \
+    uv pip install --system git+https://github.com/ckan/ckanext-harvest.git@${HARVEST_VERSION} && \
+    uv pip install --system -r https://raw.githubusercontent.com/ckan/ckanext-harvest/${HARVEST_VERSION}/requirements.txt && \
+    uv pip install --system git+https://github.com/ckan/ckanext-dcat.git@${DCAT_VERSION} && \
+    # Update plugin configuration in production.ini
     sed -i 's/^ckan.plugins =.*/ckan.plugins = '"${CKAN__PLUGINS}"'/' /app/production.ini && \
     # Add DCAT configuration directly to production.ini
     echo "" >> /app/production.ini && \
@@ -37,7 +40,7 @@ RUN uv pip install --system \
 USER ckan
 
 # Metadata labels
-LABEL description="CKAN 2.11.4 with DCAT ${DCAT_VERSION} (euro_dcat_ap_3) and scheming ${SCHEMING_VERSION}"
-LABEL extensions="ckanext-scheming==${SCHEMING_VERSION} ckanext-dcat==${DCAT_VERSION}"
+LABEL description="CKAN 2.11.4 with DCAT ${DCAT_VERSION} (euro_dcat_ap_3), scheming ${SCHEMING_VERSION}, and harvest ${HARVEST_VERSION}"
+LABEL extensions="ckanext-scheming@${SCHEMING_VERSION} ckanext-harvest@${HARVEST_VERSION} ckanext-dcat@${DCAT_VERSION}"
 LABEL maintainer="Stad Gent"
 LABEL org.opencontainers.image.source="https://github.com/MPParsley/ckan-helm"

--- a/Dockerfile.custom
+++ b/Dockerfile.custom
@@ -22,19 +22,22 @@ RUN uv pip install --system \
     # Create directory for custom schemas
     mkdir -p /app/schemas && \
     chown -R ckan:ckan /app/schemas && \
-    # Update plugin configuration in production.ini
-    ckan config-tool ${APP_DIR}/production.ini "ckan.plugins = ${CKAN__PLUGINS}" && \
-    # Add scheming configuration to production.ini
-    ckan config-tool ${APP_DIR}/production.ini "scheming.dataset_schemas = /app/schemas/dataset_schema.yaml" && \
-    ckan config-tool ${APP_DIR}/production.ini "scheming.presets = ckanext.scheming:presets.json ckanext.dcat.schemas:presets.yaml" && \
-    ckan config-tool ${APP_DIR}/production.ini "scheming.organization_schemas = ckanext.scheming:organization.json" && \
-    ckan config-tool ${APP_DIR}/production.ini "scheming.group_schemas = ckanext.scheming:group.json" && \
-    # Add DCAT configuration
-    ckan config-tool ${APP_DIR}/production.ini "ckanext.dcat.rdf.profiles = euro_dcat_ap_2 euro_dcat_ap" && \
-    ckan config-tool ${APP_DIR}/production.ini "ckanext.dcat.translate_keys = true" && \
-    ckan config-tool ${APP_DIR}/production.ini "ckanext.dcat.enable_rdf_endpoints = true" && \
-    ckan config-tool ${APP_DIR}/production.ini "ckanext.dcat.enable_content_negotiation = true" && \
-    ckan config-tool ${APP_DIR}/production.ini "ckanext.dcat.enable_dataset_rdf_endpoints = true" && \
+    # Update plugin configuration in production.ini using sed
+    sed -i 's/^ckan.plugins =.*/ckan.plugins = '"${CKAN__PLUGINS}"'/' /app/production.ini && \
+    # Add scheming and DCAT configuration directly to production.ini
+    echo "" >> /app/production.ini && \
+    echo "## Scheming Configuration" >> /app/production.ini && \
+    echo "scheming.dataset_schemas = /app/schemas/dataset_schema.yaml" >> /app/production.ini && \
+    echo "scheming.presets = ckanext.scheming:presets.json ckanext.dcat.schemas:presets.yaml" >> /app/production.ini && \
+    echo "scheming.organization_schemas = ckanext.scheming:organization.json" >> /app/production.ini && \
+    echo "scheming.group_schemas = ckanext.scheming:group.json" >> /app/production.ini && \
+    echo "" >> /app/production.ini && \
+    echo "## DCAT Configuration" >> /app/production.ini && \
+    echo "ckanext.dcat.rdf.profiles = euro_dcat_ap_2 euro_dcat_ap" >> /app/production.ini && \
+    echo "ckanext.dcat.translate_keys = true" >> /app/production.ini && \
+    echo "ckanext.dcat.enable_rdf_endpoints = true" >> /app/production.ini && \
+    echo "ckanext.dcat.enable_content_negotiation = true" >> /app/production.ini && \
+    echo "ckanext.dcat.enable_dataset_rdf_endpoints = true" >> /app/production.ini && \
     # Clean up uv cache to reduce image size
     rm -rf /root/.cache/uv
 

--- a/Dockerfile.custom
+++ b/Dockerfile.custom
@@ -24,6 +24,17 @@ RUN uv pip install --system \
     chown -R ckan:ckan /app/schemas && \
     # Update plugin configuration in production.ini
     ckan config-tool ${APP_DIR}/production.ini "ckan.plugins = ${CKAN__PLUGINS}" && \
+    # Add scheming configuration to production.ini
+    ckan config-tool ${APP_DIR}/production.ini "scheming.dataset_schemas = /app/schemas/dataset_schema.yaml" && \
+    ckan config-tool ${APP_DIR}/production.ini "scheming.presets = ckanext.scheming:presets.json ckanext.dcat.schemas:presets.yaml" && \
+    ckan config-tool ${APP_DIR}/production.ini "scheming.organization_schemas = ckanext.scheming:organization.json" && \
+    ckan config-tool ${APP_DIR}/production.ini "scheming.group_schemas = ckanext.scheming:group.json" && \
+    # Add DCAT configuration
+    ckan config-tool ${APP_DIR}/production.ini "ckanext.dcat.rdf.profiles = euro_dcat_ap_2 euro_dcat_ap" && \
+    ckan config-tool ${APP_DIR}/production.ini "ckanext.dcat.translate_keys = true" && \
+    ckan config-tool ${APP_DIR}/production.ini "ckanext.dcat.enable_rdf_endpoints = true" && \
+    ckan config-tool ${APP_DIR}/production.ini "ckanext.dcat.enable_content_negotiation = true" && \
+    ckan config-tool ${APP_DIR}/production.ini "ckanext.dcat.enable_dataset_rdf_endpoints = true" && \
     # Clean up uv cache to reduce image size
     rm -rf /root/.cache/uv
 

--- a/GITHUB_CONTAINER_REGISTRY.md
+++ b/GITHUB_CONTAINER_REGISTRY.md
@@ -1,0 +1,415 @@
+# Using Custom CKAN Image from GitHub Container Registry
+
+This repository automatically builds a custom CKAN Docker image with scheming and DCAT extensions and publishes it to GitHub Container Registry (ghcr.io).
+
+---
+
+## 🐳 Image Details
+
+**Registry**: `ghcr.io`
+**Image**: `ghcr.io/mpparsley/ckan-helm/ckan-custom`
+**Base**: `keitaro/ckan:2.11.4`
+
+### Included Extensions
+
+- ✅ **ckanext-scheming** 3.1.0 - Custom metadata schemas
+- ✅ **ckanext-dcat** 2.4.2 - RDF/DCAT metadata export
+- ✅ **rdflib** 7.0.0 - Python RDF library
+
+### Available Tags
+
+| Tag | Description | When Updated |
+|-----|-------------|--------------|
+| `latest` | Latest build from master branch | On every push to master |
+| `2.11.4-scheming3.1-dcat2.4` | Semantic version tag | On push to master |
+| `master-<sha>` | Git commit SHA | On every push to master |
+| `pr-<number>` | Pull request preview | On PR creation/update |
+
+---
+
+## 🔑 Authentication
+
+### Public Access (Default)
+
+The images are public by default. No authentication needed:
+
+```bash
+docker pull ghcr.io/mpparsley/ckan-helm/ckan-custom:latest
+```
+
+### Private Access (If Repository is Private)
+
+If the repository is private, you need a GitHub Personal Access Token (PAT):
+
+1. **Create a PAT** with `read:packages` scope:
+   - Go to https://github.com/settings/tokens
+   - Generate new token (classic)
+   - Select `read:packages` scope
+   - Copy the token
+
+2. **Login to ghcr.io**:
+   ```bash
+   echo $GITHUB_TOKEN | docker login ghcr.io -u USERNAME --password-stdin
+   ```
+
+3. **Pull the image**:
+   ```bash
+   docker pull ghcr.io/mpparsley/ckan-helm/ckan-custom:latest
+   ```
+
+---
+
+## 📦 Using in Helm Deployment
+
+### Option 1: Public Image (No Secret Needed)
+
+Update your `values-openshift.yaml`:
+
+```yaml
+image:
+  repository: ghcr.io/mpparsley/ckan-helm/ckan-custom
+  tag: "2.11.4-scheming3.1-dcat2.4"
+  pullPolicy: Always
+
+# Plugin configuration is already baked into the image
+# But you can override via extraEnv if needed
+ckan:
+  # Plugins are already configured in the image
+  # ckanPlugins will be read from production.ini in the image
+
+  # Add scheming configuration
+  extraEnv:
+    - name: CKAN__SCHEMING__DATASET_SCHEMAS
+      value: "ckanext.scheming:ckan_dataset.yaml /app/schemas/dataset_schema.yaml"
+
+    - name: CKAN__SCHEMING__PRESETS
+      value: "ckanext.scheming:presets.json ckanext.dcat.schemas:presets.yaml"
+
+    - name: CKANEXT__DCAT__RDF_PROFILES
+      value: "euro_dcat_ap_2 euro_dcat_ap"
+
+    - name: CKANEXT__DCAT__ENABLE_RDF_ENDPOINTS
+      value: "true"
+```
+
+Deploy:
+
+```bash
+helm upgrade ckan . -f values-openshift.yaml -n d09-open-data-qa
+```
+
+### Option 2: Private Image (With Pull Secret)
+
+If your repository is private, create an image pull secret:
+
+```bash
+# Create pull secret in OpenShift
+kubectl create secret docker-registry ghcr-pull-secret \
+  --docker-server=ghcr.io \
+  --docker-username=YOUR_GITHUB_USERNAME \
+  --docker-password=YOUR_GITHUB_PAT \
+  --docker-email=YOUR_EMAIL \
+  -n d09-open-data-qa
+```
+
+Update `values-openshift.yaml`:
+
+```yaml
+image:
+  repository: ghcr.io/mpparsley/ckan-helm/ckan-custom
+  tag: "2.11.4-scheming3.1-dcat2.4"
+  pullPolicy: Always
+
+imagePullSecrets:
+  - name: ghcr-pull-secret
+
+ckan:
+  extraEnv:
+    - name: CKAN__SCHEMING__DATASET_SCHEMAS
+      value: "/app/schemas/dataset_schema.yaml"
+    - name: CKANEXT__DCAT__ENABLE_RDF_ENDPOINTS
+      value: "true"
+```
+
+---
+
+## 🚀 GitHub Actions Workflow
+
+### Automatic Builds
+
+The workflow (`.github/workflows/build-custom-ckan-image.yaml`) automatically builds on:
+
+- ✅ Push to `master` or `main` branch
+- ✅ Pull requests (preview builds)
+- ✅ Manual trigger via GitHub UI
+- ✅ Changes to `Dockerfile.custom` or `schemas/`
+
+### Manual Trigger
+
+You can manually trigger a build:
+
+1. Go to **Actions** tab in GitHub
+2. Select **Build and Push Custom CKAN Image**
+3. Click **Run workflow**
+4. Optional: Add a tag suffix (e.g., `-test`, `-beta`)
+
+### Build Cache
+
+The workflow uses GitHub Actions cache to speed up builds:
+- First build: ~5-10 minutes
+- Subsequent builds: ~2-3 minutes (with cache)
+
+---
+
+## 🔍 Verifying the Image
+
+### Check Available Tags
+
+```bash
+# List all tags (requires gh CLI)
+gh api /user/packages/container/ckan-helm%2Fckan-custom/versions \
+  --jq '.[].metadata.container.tags[]' | sort -u
+```
+
+### Inspect Image
+
+```bash
+# Pull and inspect
+docker pull ghcr.io/mpparsley/ckan-helm/ckan-custom:latest
+
+# Check installed extensions
+docker run --rm ghcr.io/mpparsley/ckan-helm/ckan-custom:latest \
+  pip list | grep ckanext
+
+# Expected output:
+# ckanext-dcat        2.4.2
+# ckanext-scheming    3.1.0
+
+# Check plugins configuration
+docker run --rm ghcr.io/mpparsley/ckan-helm/ckan-custom:latest \
+  grep "ckan.plugins" /app/production.ini
+
+# Expected output:
+# ckan.plugins = envvars activity image_view text_view datatables_view datastore xloader scheming_datasets dcat dcat_json_interface structured_data
+```
+
+### Test Locally
+
+```bash
+# Run locally with docker-compose
+docker run -p 5000:5000 \
+  -e CKAN_SQLALCHEMY_URL=postgresql://ckan:pass@postgres/ckan \
+  -e CKAN_SOLR_URL=http://solr:8983/solr/ckan \
+  -e CKAN_REDIS_URL=redis://redis:6379/0 \
+  ghcr.io/mpparsley/ckan-helm/ckan-custom:latest
+```
+
+---
+
+## 📝 Making Changes
+
+### Updating Extensions
+
+1. **Edit `Dockerfile.custom`**:
+   ```dockerfile
+   ENV SCHEMING_VERSION="3.2.0"  # Update version
+   ENV DCAT_VERSION="2.5.0"      # Update version
+   ```
+
+2. **Update semantic tag in workflow** (`.github/workflows/build-custom-ckan-image.yaml`):
+   ```yaml
+   type=raw,value=2.11.4-scheming3.2-dcat2.5
+   ```
+
+3. **Commit and push**:
+   ```bash
+   git add Dockerfile.custom .github/workflows/build-custom-ckan-image.yaml
+   git commit -m "Update extensions: scheming 3.2.0, DCAT 2.5.0"
+   git push origin master
+   ```
+
+4. **GitHub Actions will automatically build** and push the new image
+
+### Adding New Extensions
+
+1. **Edit `Dockerfile.custom`**:
+   ```dockerfile
+   ENV HARVEST_VERSION="1.5.6"
+
+   RUN uv pip install --system \
+       ckanext-scheming==${SCHEMING_VERSION} \
+       ckanext-dcat==${DCAT_VERSION} \
+       ckanext-harvest==${HARVEST_VERSION} \
+       rdflib==${RDFLIB_VERSION}
+   ```
+
+2. **Update plugin list**:
+   ```dockerfile
+   ENV CKAN__PLUGINS="envvars ... scheming_datasets dcat harvest ckan_harvester"
+   ```
+
+3. **Commit, push, and let GitHub Actions build**
+
+---
+
+## 🔒 Security Considerations
+
+### Image Scanning
+
+The workflow includes basic security practices:
+- ✅ Uses official GitHub Actions
+- ✅ Minimal base image (Alpine-based)
+- ✅ Non-root user (ckan user)
+- ✅ Version pinning for all extensions
+
+### Recommended: Add Vulnerability Scanning
+
+You can add Trivy scanning to the workflow:
+
+```yaml
+- name: Run Trivy vulnerability scanner
+  uses: aquasecurity/trivy-action@master
+  with:
+    image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+    format: 'sarif'
+    output: 'trivy-results.sarif'
+
+- name: Upload Trivy results to GitHub Security
+  uses: github/codeql-action/upload-sarif@v2
+  with:
+    sarif_file: 'trivy-results.sarif'
+```
+
+---
+
+## 🆘 Troubleshooting
+
+### Build Fails on GitHub Actions
+
+**Check the Actions logs**:
+1. Go to **Actions** tab
+2. Click on the failed workflow
+3. Check the **Build and push Docker image** step
+
+Common issues:
+- **Schema file missing**: Ensure `schemas/dataset_schema.yaml` exists
+- **Permission denied**: Check repository permissions for GITHUB_TOKEN
+- **Rate limit**: Wait a few minutes and retry
+
+### Image Pull Fails in OpenShift
+
+**Error**: `ErrImagePull` or `ImagePullBackOff`
+
+**Solutions**:
+
+1. **Check image exists**:
+   ```bash
+   docker pull ghcr.io/mpparsley/ckan-helm/ckan-custom:latest
+   ```
+
+2. **For private repos, create pull secret**:
+   ```bash
+   kubectl create secret docker-registry ghcr-pull-secret \
+     --docker-server=ghcr.io \
+     --docker-username=YOUR_USERNAME \
+     --docker-password=YOUR_PAT \
+     -n d09-open-data-qa
+   ```
+
+3. **Add secret to values**:
+   ```yaml
+   imagePullSecrets:
+     - name: ghcr-pull-secret
+   ```
+
+### Plugins Not Loading
+
+**Check pod logs**:
+```bash
+kubectl logs -n d09-open-data-qa deployment/ckan | grep -i "plugin\|error"
+```
+
+**Common issues**:
+- Plugin not in CKAN__PLUGINS list
+- Missing configuration (check extraEnv)
+- Extension dependencies not installed
+
+---
+
+## 📊 Monitoring Builds
+
+### GitHub Actions Badge
+
+Add to your README:
+
+```markdown
+[![Build Custom CKAN Image](https://github.com/MPParsley/ckan-helm/actions/workflows/build-custom-ckan-image.yaml/badge.svg)](https://github.com/MPParsley/ckan-helm/actions/workflows/build-custom-ckan-image.yaml)
+```
+
+### Check Latest Build
+
+```bash
+# Using gh CLI
+gh run list --workflow=build-custom-ckan-image.yaml --limit 5
+
+# Check specific run
+gh run view <run-id>
+```
+
+---
+
+## 🎯 Quick Start for QA Deployment
+
+```bash
+# 1. Ensure schemas directory exists
+mkdir -p schemas
+# (dataset_schema.yaml should already be there)
+
+# 2. Commit and push Dockerfile.custom
+git add Dockerfile.custom schemas/
+git commit -m "Add custom CKAN image with scheming and DCAT"
+git push origin master
+
+# 3. Wait for GitHub Actions to build (~5-10 minutes)
+# Check: https://github.com/MPParsley/ckan-helm/actions
+
+# 4. Update values-openshift.yaml
+cat >> values-openshift.yaml <<EOF
+image:
+  repository: ghcr.io/mpparsley/ckan-helm/ckan-custom
+  tag: "2.11.4-scheming3.1-dcat2.4"
+  pullPolicy: Always
+
+ckan:
+  extraEnv:
+    - name: CKAN__SCHEMING__DATASET_SCHEMAS
+      value: "/app/schemas/dataset_schema.yaml"
+    - name: CKANEXT__DCAT__RDF_PROFILES
+      value: "euro_dcat_ap_2"
+    - name: CKANEXT__DCAT__ENABLE_RDF_ENDPOINTS
+      value: "true"
+EOF
+
+# 5. Deploy to QA
+helm upgrade ckan . -f values-openshift.yaml -n d09-open-data-qa
+
+# 6. Verify deployment
+kubectl get pods -n d09-open-data-qa -l app.kubernetes.io/name=ckan
+kubectl logs -n d09-open-data-qa deployment/ckan | grep "Loading plugin"
+```
+
+---
+
+## 📚 Resources
+
+- [GitHub Container Registry Docs](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)
+- [Docker Build Push Action](https://github.com/docker/build-push-action)
+- [CKAN Extension Development](https://docs.ckan.org/en/latest/extensions/index.html)
+- [CKAN Scheming](https://github.com/ckan/ckanext-scheming)
+- [CKAN DCAT](https://github.com/ckan/ckanext-dcat)
+
+---
+
+**Ready to deploy!** 🚀
+
+The custom image will be automatically built and pushed to GitHub Container Registry on every push to master.

--- a/schemas/dataset_schema.yaml
+++ b/schemas/dataset_schema.yaml
@@ -1,0 +1,103 @@
+scheming_version: 2
+dataset_type: dataset
+about: Custom dataset schema met Linked Data en GIS velden voor Stad Gent
+about_url: https://github.com/ckan/ckanext-scheming
+
+dataset_fields:
+  # Standaard CKAN velden
+  - field_name: title
+    label: Titel
+    preset: title
+    form_placeholder: Titel van de dataset
+    required: true
+
+  - field_name: name
+    label: URL
+    preset: dataset_slug
+    form_placeholder: bv-mijn-dataset
+
+  - field_name: notes
+    label: Beschrijving
+    form_snippet: markdown.html
+    form_placeholder: Beschrijving van de dataset
+    required: true
+
+  - field_name: tag_string
+    label: Tags
+    preset: tag_string_autocomplete
+    form_placeholder: bv. economie, mobiliteit, linked-data
+
+  - field_name: owner_org
+    label: Organisatie
+    preset: dataset_organization
+
+  # Custom velden voor Linked Data
+  - field_name: linked_data
+    label: Linked Data beschikbaar?
+    help_text: Is deze dataset beschikbaar als Linked Open Data?
+    preset: select
+    required: false
+    choices:
+      - value: "true"
+        label: Ja
+      - value: "false"
+        label: Nee
+    form_placeholder: Selecteer ja of nee
+
+  - field_name: data_category
+    label: Data Categorie
+    help_text: Type data dat deze dataset bevat
+    preset: select
+    required: false
+    choices:
+      - value: GIS
+        label: GIS (Geo-informatie)
+      - value: ODP
+        label: ODP (Open Data Portal)
+      - value: LOD
+        label: LOD (Linked Open Data)
+      - value: API
+        label: API
+      - value: OTHER
+        label: Anders
+    form_placeholder: Selecteer categorie
+
+  - field_name: lod_url
+    label: Linked Data URL
+    help_text: URL naar het LOD/SPARQL endpoint (indien van toepassing)
+    form_snippet: text.html
+    display_snippet: link.html
+    form_placeholder: https://example.org/sparql
+    required: false
+
+  - field_name: gis_service_url
+    label: GIS Service URL
+    help_text: URL naar WMS/WFS of andere GIS service (indien van toepassing)
+    form_snippet: text.html
+    display_snippet: link.html
+    form_placeholder: https://geo.example.org/wms
+    required: false
+
+  # Standaard velden
+  - field_name: license_id
+    label: Licentie
+    form_snippet: license.html
+    help_text: Selecteer de licentie voor deze dataset
+
+resource_fields:
+  - field_name: url
+    label: URL
+    preset: resource_url_upload
+
+  - field_name: name
+    label: Naam
+    form_placeholder: bv. Januari 2025 data
+
+  - field_name: description
+    label: Beschrijving
+    form_snippet: markdown.html
+    form_placeholder: Beschrijving van deze resource
+
+  - field_name: format
+    label: Formaat
+    preset: resource_format_autocomplete

--- a/schemas/dcat_ap_stadgent.yaml
+++ b/schemas/dcat_ap_stadgent.yaml
@@ -1,0 +1,694 @@
+scheming_version: 2
+dataset_type: dataset
+about: Full DCAT AP (2 and 3) schema
+about_url: http://github.com/ckan/ckanext-dcat
+
+dataset_fields:
+
+- field_name: title
+  label: Title
+  preset: title
+  required: true
+  help_text: A descriptive title for the dataset.
+
+- field_name: name
+  label: URL
+  preset: dataset_slug
+  form_placeholder: eg. my-dataset
+
+- field_name: notes
+  label: Description
+  required: true
+  form_snippet: markdown.html
+  help_text: A free-text account of the dataset.
+
+- field_name: tag_string
+  label: Keywords
+  preset: tag_string_autocomplete
+  form_placeholder: eg. economy, mental health, government
+  help_text: Keywords or tags describing the dataset. Use commas to separate multiple values.
+
+- field_name: contact
+  label: Contact points
+  repeating_label: Contact point
+  repeating_subfields:
+
+    - field_name: uri
+      label: URI
+
+    - field_name: name
+      label: Name
+
+    - field_name: email
+      label: Email
+      display_snippet: email.html
+
+    - field_name: identifier
+      label: Identifier
+      help_text: Unique identifier for the contact point. Such as a ROR ID.
+    
+    - field_name: url
+      label: URL
+      help_text: A URL associated with the contact
+  help_text: Contact information for enquiries about the dataset.
+
+- field_name: publisher
+  label: Publisher
+  repeating_label: Publisher
+  repeating_once: true
+  repeating_subfields:
+
+    - field_name: uri
+      label: URI
+
+    - field_name: name
+      label: Name
+
+    - field_name: email
+      label: Email
+      display_snippet: email.html
+
+    - field_name: url
+      label: URL
+      display_snippet: link.html
+
+    - field_name: type
+      label: Type
+
+    - field_name: identifier
+      label: Identifier
+      help_text: Unique identifier for the publisher, such as a ROR ID.
+  help_text: Entity responsible for making the dataset available.
+
+- field_name: creator
+  label: Creator
+  repeating_label: Creator
+  repeating_once: true
+  repeating_subfields:
+
+    - field_name: uri
+      label: URI
+      help_text: URI of the creator, if available.
+
+    - field_name: name
+      label: Name
+      help_text: Name of the entity or person who created the dataset.
+
+    - field_name: email
+      label: Email
+      display_snippet: email.html
+      help_text: Contact email of the creator.
+
+    - field_name: url
+      label: URL
+      display_snippet: link.html
+      help_text: URL for more information about the creator.
+
+    - field_name: type
+      label: Type
+      help_text: Type of creator (e.g., Organization, Person).
+
+    - field_name: identifier
+      label: Identifier
+      help_text: Unique identifier for the creator, such as an ORCID or ROR ID.
+
+- field_name: homepage
+  label: Homepage
+  display_snippet: link.html
+  help_text: A web page that acts as the homepage for the dataset.
+
+- field_name: license_id
+  label: License
+  form_snippet: license.html
+  help_text: License definitions and additional information can be found at http://opendefinition.org/.
+
+- field_name: owner_org
+  label: Organization
+  preset: dataset_organization
+  help_text: The CKAN organization the dataset belongs to.
+
+- field_name: url
+  label: Landing page
+  form_placeholder: http://example.com/dataset.json
+  display_snippet: link.html
+  help_text: Web page that can be navigated to gain access to the dataset, its distributions and/or additional information.
+
+  # Note: this will fall back to metadata_created if not present
+- field_name: issued
+  label: Release date
+  preset: dcat_date
+  help_text: Date of publication of the dataset.
+
+  # Note: this will fall back to metadata_modified if not present
+- field_name: modified
+  label: Modification date
+  preset: dcat_date
+  help_text: Most recent date on which the dataset was changed, updated or modified.
+
+- field_name: version
+  label: Version
+  validators: ignore_missing unicode_safe package_version_validator
+  help_text: Version number or other version designation of the dataset.
+
+- field_name: version_notes
+  label: Version notes
+  validators: ignore_missing unicode_safe
+  form_snippet: markdown.html
+  display_snippet: markdown.html
+  help_text: A description of the differences between this version and a previous version of the dataset.
+
+  # Note: CKAN will generate a unique identifier for each dataset
+- field_name: identifier
+  label: Identifier
+  help_text: A unique identifier of the dataset.
+
+- field_name: frequency
+  label: Frequency
+  help_text: The frequency at which dataset is published.
+
+- field_name: provenance
+  label: Provenance
+  form_snippet: markdown.html
+  display_snippet: markdown.html
+  help_text: A statement about the lineage of the dataset.
+
+- field_name: dcat_type
+  label: Type
+  help_text: The type of the dataset.
+  # TODO: controlled vocabulary?
+
+- field_name: temporal_coverage
+  label: Temporal coverage
+  repeating_subfields:
+
+    - field_name: start
+      label: Start
+      preset: dcat_date
+
+    - field_name: end
+      label: End
+      preset: dcat_date
+  help_text: The temporal period or periods the dataset covers.
+
+- field_name: temporal_resolution
+  label: Temporal resolution
+  help_text: Minimum time period resolvable in the dataset.
+
+- field_name: spatial_coverage
+  label: Spatial coverage
+  repeating_subfields:
+
+    - field_name: uri
+      label: URI
+
+    - field_name: text
+      label: Label
+
+    - field_name: geom
+      label: Geometry
+
+    - field_name: bbox
+      label: Bounding Box
+
+    - field_name: centroid
+      label: Centroid
+  help_text: A geographic region that is covered by the dataset.
+
+- field_name: spatial_resolution_in_meters
+  label: Spatial resolution in meters
+  help_text: Minimum spatial separation resolvable in a dataset, measured in meters.
+
+- field_name: access_rights
+  label: Access rights
+  validators: ignore_missing unicode_safe
+  help_text: Information that indicates whether the dataset is Open Data, has access restrictions or is not public.
+
+- field_name: alternate_identifier
+  label: Other identifier
+  preset: multiple_text
+  validators: ignore_missing scheming_multiple_text
+  help_text: This property refers to a secondary identifier of the dataset, such as MAST/ADS, DataCite, DOI, etc.
+
+- field_name: theme
+  label: Theme
+  preset: multiple_text
+  validators: ignore_missing scheming_multiple_text
+  help_text: A category of the dataset. A Dataset may be associated with multiple themes.
+
+- field_name: language
+  label: Language
+  preset: multiple_text
+  validators: ignore_missing scheming_multiple_text
+  help_text: Language or languages of the dataset.
+  # TODO: language form snippet / validator / graph
+
+- field_name: documentation
+  label: Documentation
+  preset: multiple_text
+  validators: ignore_missing scheming_multiple_text
+  help_text: A page or document about this dataset.
+
+- field_name: conforms_to
+  label: Conforms to
+  preset: multiple_text
+  validators: ignore_missing scheming_multiple_text
+  help_text: An implementing rule or other specification that the dataset follows.
+
+- field_name: is_referenced_by
+  label: Is referenced by
+  preset: multiple_text
+  validators: ignore_missing scheming_multiple_text
+  help_text: A related resource, such as a publication, that references, cites, or otherwise points to the dataset.
+
+- field_name: applicable_legislation
+  label: Applicable legislation
+  preset: multiple_text
+  validators: ignore_missing scheming_multiple_text
+  help_text: The legislation that mandates the creation or management of the dataset.
+
+- field_name: has_version
+  label: Has version
+  preset: multiple_text
+  validators: ignore_missing scheming_multiple_text
+  help_inline: true
+  help_text: This property refers to a related Dataset that is a version, edition, or adaptation of the described Dataset.
+
+- field_name: qualified_relation
+  label: Qualified relation
+  repeating_label: Relationship
+  repeating_subfields:
+
+    - field_name: uri
+      label: URI
+
+    - field_name: relation
+      label: Relation
+      help_text: The resource related to the source resource.
+
+    - field_name: role
+      label: Role
+      help_text: The function of an entity or agent with respect to another entity or resource.
+  help_text: A description of a relationship with another resource.
+
+- field_name: provenance_activity
+  label: Provenance Activity
+  repeating_label: Provenance Activity
+  repeating_once: true
+  repeating_subfields:
+    - field_name: uri
+      label: Activity URI
+      help_text: URI of the provenance activity (if available).
+    - field_name: label
+      label: Label
+      help_text: Human-readable label for the activity.
+    - field_name: seeAlso
+      label: See Also
+      help_text: Related link for the activity.
+    - field_name: dct_type
+      label: Type
+      help_text: Type of the activity (URI).
+    - field_name: startedAtTime
+      label: Started At Time
+      help_text: When the activity started (ISO 8601).
+    - field_name: wasAssociatedWith
+      label: Associated Agent
+      repeating_label: Agent
+      repeating_once: true
+      repeating_subfields:
+        - field_name: uri
+          label: URI
+        - field_name: name
+          label: Name
+        - field_name: email
+          label: Email
+        - field_name: homepage
+          label: Homepage
+        - field_name: type
+          label: Type
+        - field_name: identifier
+          label: Identifier
+        - field_name: url
+          label: URL
+        - field_name: actedOnBehalfOf
+          label: Acted On Behalf Of
+          repeating_label: Organization
+          repeating_once: true
+          repeating_subfields:
+            - field_name: name
+              label: Organization Name
+  help_text: Structured provenance activity information, including agent and organization.
+
+# Add qualified_attribution field here, just before the commented-out hvd_category field
+- field_name: qualified_attribution
+  label: Qualified Attribution
+  repeating_label: Attribution
+  repeating_once: true
+  repeating_subfields:
+    - field_name: agent
+      label: Agent
+      repeating_label: Agent
+      repeating_once: true
+      repeating_subfields:
+        - field_name: uri
+          label: URI
+        - field_name: name
+          label: Name
+        - field_name: email
+          label: Email
+        - field_name: homepage
+          label: Homepage
+        - field_name: type
+          label: Type
+        - field_name: identifier
+          label: Identifier
+        - field_name: url
+          label: URL
+    - field_name: role
+      label: Role
+      help_text: Role of the agent (e.g., data processor, contributor).
+  help_text: Structured qualified attribution information including agent and role.
+
+
+#- field_name: hvd_category
+#  label: HVD Category
+#  preset: multiple_text
+#  validators: ignore_missing scheming_multiple_text
+# TODO: implement separately as part of wider HVD support
+
+# Note: if not provided, this will be autogenerated
+- field_name: uri
+  label: URI
+  help_text: An URI for this dataset (if not provided it will be autogenerated).
+
+# TODO: relation-based properties are not yet included (e.g. is_version_of, source, sample, etc)
+#
+resource_fields:
+
+- field_name: url
+  label: URL
+  preset: resource_url_upload
+
+- field_name: name
+  label: Name
+  form_placeholder:
+  help_text: A descriptive title for the resource.
+
+- field_name: description
+  label: Description
+  form_snippet: markdown.html
+  help_text: A free-text account of the resource.
+
+- field_name: format
+  label: Format
+  preset: resource_format_autocomplete
+  help_text: File format. If not provided it will be guessed.
+
+- field_name: mimetype
+  label: Media type
+  validators: if_empty_guess_format ignore_missing unicode_safe
+  help_text: Media type for this format. If not provided it will be guessed.
+
+- field_name: compress_format
+  label: Compress format
+  help_text: The format of the file in which the data is contained in a compressed form.
+
+- field_name: package_format
+  label: Package format
+  help_text: The format of the file in which one or more data files are grouped together.
+
+- field_name: size
+  label: Size
+  validators: ignore_missing int_validator
+  form_snippet: number.html
+  display_snippet: file_size.html
+  help_text: File size in bytes
+
+- field_name: hash
+  label: Hash
+  help_text: Checksum of the downloaded file.
+
+- field_name: hash_algorithm
+  label: Hash Algorithm
+  help_text: Algorithm used to calculate to checksum.
+
+- field_name: rights
+  label: Rights
+  form_snippet: markdown.html
+  display_snippet: markdown.html
+  help_text: Some statement about the rights associated with the resource.
+
+- field_name: availability
+  label: Availability
+  help_text: Indicates how long it is planned to keep the resource available.
+
+- field_name: status
+  label: Status
+  preset: select
+  choices:
+    - value: http://purl.org/adms/status/Completed
+      label: Completed
+    - value: http://purl.org/adms/status/UnderDevelopment
+      label: Under Development
+    - value: http://purl.org/adms/status/Deprecated
+      label: Deprecated
+    - value: http://purl.org/adms/status/Withdrawn
+      label: Withdrawn
+  help_text: The status of the resource in the context of maturity lifecycle.
+
+- field_name: license
+  label: License
+  help_text: License in which the resource is made available. If not provided will be inherited from the dataset.
+
+  # Note: this falls back to the standard resource url field
+- field_name: access_url
+  label: Access URL
+  help_text: URL that gives access to the dataset (defaults to the standard resource URL).
+
+  # Note: this falls back to the standard resource url field
+- field_name: download_url
+  label: Download URL
+  display_snippet: link.html
+  help_text: URL that provides a direct link to a downloadable file (defaults to the standard resource URL).
+
+- field_name: issued
+  label: Release date
+  preset: dcat_date
+  help_text: Date of publication of the resource.
+
+- field_name: modified
+  label: Modification date
+  preset: dcat_date
+  help_text: Most recent date on which the resource was changed, updated or modified.
+
+- field_name: temporal_resolution
+  label: Temporal resolution
+  help_text: Minimum time period resolvable in the distribution.
+
+- field_name: spatial_resolution_in_meters
+  label: Spatial resolution in meters
+  help_text: Minimum spatial separation resolvable in the distribution, measured in meters.
+
+- field_name: language
+  label: Language
+  preset: multiple_text
+  validators: ignore_missing scheming_multiple_text
+  help_text: Language or languages of the resource.
+
+- field_name: documentation
+  label: Documentation
+  preset: multiple_text
+  validators: ignore_missing scheming_multiple_text
+  help_text: A page or document about this resource.
+
+- field_name: conforms_to
+  label: Conforms to
+  preset: multiple_text
+  validators: ignore_missing scheming_multiple_text
+  help_text: An established schema to which the described resource conforms.
+
+- field_name: applicable_legislation
+  label: Applicable legislation
+  preset: multiple_text
+  validators: ignore_missing scheming_multiple_text
+  help_text: The legislation that mandates the creation or management of the resource.
+
+- field_name: access_services
+  label: Access services
+  repeating_label: Access service
+  repeating_subfields:
+
+    - field_name: uri
+      label: URI
+
+    - field_name: title
+      label: Title
+
+    - field_name: description
+      label: Description
+      form_snippet: markdown.html
+      help_text: A free-text account of the resource.
+
+    - field_name: endpoint_description
+      label: Endpoint description
+
+    - field_name: endpoint_url
+      label: Endpoint URL
+      preset: multiple_text
+
+    - field_name: serves_dataset
+      label: Serves dataset
+      preset: multiple_text
+      validators: ignore_missing scheming_multiple_text
+
+    - field_name: access_rights
+      label: Access rights
+      validators: ignore_missing unicode_safe
+      help_text: Information regarding access or restrictions based on privacy, security, or other policies.
+
+    - field_name: conforms_to
+      label: Conforms to
+      preset: multiple_text
+      validators: ignore_missing scheming_multiple_text
+
+    - field_name: format
+      label: Format
+      preset: multiple_text
+      validators: ignore_missing scheming_multiple_text
+
+    - field_name: identifier
+      label: Identifier
+
+    - field_name: language
+      label: Language
+      preset: multiple_text
+      validators: ignore_missing scheming_multiple_text
+
+    - field_name: rights
+      label: Rights
+      form_snippet: markdown.html
+      display_snippet: markdown.html
+      preset: multiple_text
+      validators: ignore_missing scheming_multiple_text
+
+    - field_name: landing_page
+      label: Landing page
+      preset: multiple_text
+      validators: ignore_missing scheming_multiple_text
+
+    - field_name: keyword
+      label: Keywords
+      preset: tag_string_autocomplete
+      form_placeholder: eg. economy, mental health, government
+      help_text: Keywords or tags describing the dataservice. Use commas to separate multiple values.
+    
+    - field_name: applicable_legislation
+      label: Applicable legislation
+      preset: multiple_text
+      validators: ignore_missing scheming_multiple_text
+      help_text: The legislation that mandates the creation or management of the dataset.
+
+    - field_name: contact
+      label: Contact point
+      repeating_label: Contact point
+      repeating_once: true
+      repeating_subfields:
+
+        - field_name: uri
+          label: URI
+
+        - field_name: name
+          label: Name
+
+        - field_name: email
+          label: Email
+          display_snippet: email.html
+
+        - field_name: identifier
+          label: Identifier
+          help_text: Unique identifier for the contact point. Such as a ROR ID.
+        
+        - field_name: url
+          label: URL
+          help_text: A URL associated with the contact
+      help_text: Contact information for enquiries about the dataservice.
+
+    - field_name: creator
+      label: Creator
+      repeating_label: Creator
+      repeating_subfields:
+
+        - field_name: uri
+          label: URI
+          help_text: URI of the creator, if available.
+
+        - field_name: name
+          label: Name
+          help_text: Name of the entity or person who created the dataservice.
+
+        - field_name: email
+          label: Email
+          display_snippet: email.html
+          help_text: Contact email of the creator.
+
+        - field_name: url
+          label: URL
+          display_snippet: link.html
+          help_text: URL for more information about the creator.
+
+        - field_name: type
+          label: Type
+          help_text: Type of creator (e.g., Organization, Person).
+
+        - field_name: identifier
+          label: Identifier
+          help_text: Unique identifier for the creator, such as an ORCID or ROR ID.
+
+    - field_name: publisher
+      label: Publisher
+      repeating_label: Publisher
+      repeating_once: true
+      repeating_subfields:
+
+        - field_name: uri
+          label: URI
+
+        - field_name: name
+          label: Name
+
+        - field_name: email
+          label: Email
+          display_snippet: email.html
+
+        - field_name: url
+          label: URL
+          display_snippet: link.html
+
+        - field_name: type
+          label: Type
+
+        - field_name: identifier
+          label: Identifier
+          help_text: Unique identifier for the publisher, such as a ROR ID.
+      help_text: Entity responsible for making the dataset available.
+
+    - field_name: license
+      label: License
+      help_text: License in which the resource is made available. If not provided will be inherited from the dataset.
+
+    - field_name: modified
+      label: Modification date
+      preset: dcat_date
+      help_text: Most recent date on which the dataset was changed, updated or modified.
+
+    - field_name: theme
+      label: Theme
+      preset: multiple_text
+      validators: ignore_missing scheming_multiple_text
+      help_text: A category of the dataservice. A Dataservice may be associated with multiple themes.
+
+  help_text: A data service that gives access to the resource.
+
+  # Note: if not provided, this will be autogenerated
+- field_name: uri
+  label: URI
+  help_text: An URI for this resource (if not provided it will be autogenerated).

--- a/schemas/dcat_ap_stadgent.yaml
+++ b/schemas/dcat_ap_stadgent.yaml
@@ -39,8 +39,8 @@ dataset_fields:
 - field_name: project_code
   label: Projectcode
   form_placeholder: Bijv. STAD-2024-001
-  validators: ignore_missing project_code_validator
-  help_text: Projectcode in formaat STAD-YYYY-NNN (verplicht formaat).
+  validators: ignore_missing unicode_safe
+  help_text: Projectcode in formaat STAD-YYYY-NNN (validatie volgt later).
 
 - field_name: data_quality
   label: Datakwaliteit

--- a/schemas/dcat_ap_stadgent.yaml
+++ b/schemas/dcat_ap_stadgent.yaml
@@ -39,8 +39,8 @@ dataset_fields:
 - field_name: project_code
   label: Projectcode
   form_placeholder: Bijv. STAD-2024-001
-  validators: ignore_missing unicode_safe
-  help_text: Projectcode in formaat STAD-YYYY-NNN.
+  validators: ignore_missing project_code_validator
+  help_text: Projectcode in formaat STAD-YYYY-NNN (verplicht formaat).
 
 - field_name: data_quality
   label: Datakwaliteit

--- a/schemas/dcat_ap_stadgent.yaml
+++ b/schemas/dcat_ap_stadgent.yaml
@@ -1,7 +1,7 @@
 scheming_version: 2
 dataset_type: dataset
-about: Full DCAT AP (2 and 3) schema
-about_url: http://github.com/ckan/ckanext-dcat
+about: Stad Gent DCAT AP schema (based on DCAT AP 2 and 3)
+about_url: https://github.com/MPParsley/ckan-helm
 
 dataset_fields:
 
@@ -21,6 +21,13 @@ dataset_fields:
   required: true
   form_snippet: markdown.html
   help_text: A free-text account of the dataset.
+
+- field_name: license_id
+  label: License
+  form_snippet: license.html
+  required: true
+  validators: not_empty unicode_safe
+  help_text: License definitions and additional information can be found at http://opendefinition.org/.
 
 - field_name: tag_string
   label: Keywords
@@ -117,11 +124,6 @@ dataset_fields:
   display_snippet: link.html
   help_text: A web page that acts as the homepage for the dataset.
 
-- field_name: license_id
-  label: License
-  form_snippet: license.html
-  help_text: License definitions and additional information can be found at http://opendefinition.org/.
-
 - field_name: owner_org
   label: Organization
   preset: dataset_organization
@@ -164,7 +166,8 @@ dataset_fields:
 
 - field_name: frequency
   label: Frequency
-  help_text: The frequency at which dataset is published.
+  form_snippet: null
+  help_text: The frequency at which dataset is published (hidden from form).
 
 - field_name: provenance
   label: Provenance

--- a/schemas/dcat_ap_stadgent.yaml
+++ b/schemas/dcat_ap_stadgent.yaml
@@ -29,6 +29,44 @@ dataset_fields:
   validators: not_empty unicode_safe
   help_text: License definitions and additional information can be found at http://opendefinition.org/.
 
+# Custom Stad Gent metadata fields
+- field_name: internal_reference
+  label: Interne Referentie
+  form_placeholder: Bijv. PRJ-2024-001
+  validators: ignore_missing unicode_safe
+  help_text: Interne referentie voor dit project of dataset.
+
+- field_name: project_code
+  label: Projectcode
+  form_placeholder: Bijv. STAD-2024-001
+  validators: ignore_missing unicode_safe
+  help_text: Projectcode in formaat STAD-YYYY-NNN.
+
+- field_name: data_quality
+  label: Datakwaliteit
+  preset: select
+  choices:
+    - value: high
+      label: Hoog
+    - value: medium
+      label: Gemiddeld
+    - value: low
+      label: Laag
+  help_text: Beoordeling van de datakwaliteit.
+
+- field_name: themas
+  label: Thema's
+  preset: tag_string_autocomplete
+  form_placeholder: Bijv. mobiliteit, duurzaamheid, klimaat
+  help_text: Thematische categorieën voor deze dataset.
+
+- field_name: related_system_url
+  label: Gerelateerd Systeem URL
+  validators: ignore_missing url_validator
+  display_snippet: link.html
+  form_placeholder: https://example.com/system
+  help_text: URL naar gerelateerd systeem of applicatie.
+
 - field_name: tag_string
   label: Keywords
   preset: tag_string_autocomplete

--- a/templates/ckan_workers.yaml
+++ b/templates/ckan_workers.yaml
@@ -42,10 +42,12 @@ spec:
           image: postgres:17-alpine
           securityContext:
             {{- toYaml $.Values.securityContext | nindent 12 }}
+            {{- if not $.Values.openshift.enabled }}
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
+            {{- end }}
           command:
             - sh
             - -c
@@ -77,10 +79,12 @@ spec:
           image: curlimages/curl:8.17.0
           securityContext:
             {{- toYaml $.Values.securityContext | nindent 12 }}
+            {{- if not $.Values.openshift.enabled }}
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
+            {{- end }}
           command:
             - sh
             - -c
@@ -112,10 +116,12 @@ spec:
           imagePullPolicy: {{ $.Values.image.pullPolicy }}
           securityContext:
             {{- toYaml $.Values.securityContext | nindent 12 }}
+            {{- if not $.Values.openshift.enabled }}
             runAsNonRoot: true
             readOnlyRootFilesystem: true
             seccompProfile:
               type: RuntimeDefault
+            {{- end }}
           env:
             {{- if $.Values.ckan.extraEnv }}
             {{ toYaml $.Values.ckan.extraEnv | nindent 12 }}

--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -13,14 +13,18 @@ spec:
         spec:
           securityContext:
             {{- toYaml .Values.podSecurityContext | nindent 12 }}
+            {{- if not .Values.openshift.enabled }}
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
+            {{- end }}
           containers:
             - name: ckan-email-notifications
               securityContext:
                 {{- toYaml .Values.securityContext | nindent 16 }}
+                {{- if not .Values.openshift.enabled }}
                 readOnlyRootFilesystem: true
+                {{- end }}
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
               command: ["curl"]

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -39,9 +39,10 @@ spec:
           emptyDir: {}
       initContainers:
         {{- if .Values.pvc.enabled }}
+        {{- if not .Values.openshift.enabled }}
         - name: set-volume-ownsership
           image: "{{ .Values.image.initContainer.repository }}:{{ .Values.image.initContainer.tag }}"
-          securityContext: 
+          securityContext:
             runAsUser: 0
             runAsGroup: 0
             allowPrivilegeEscalation: false
@@ -54,14 +55,17 @@ spec:
               mountPath: {{ .Values.ckan.storagePath }}
               readOnly: false
         {{- end }}
+        {{- end }}
         - name: copy-writable-config
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           securityContext:
             {{- toYaml $.Values.securityContext | nindent 12 }}
+            {{- if not .Values.openshift.enabled }}
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
+            {{- end }}
           command: ["sh", "-c", "cp /app/production.ini /writable-config/production.ini"]
           volumeMounts:
             - name: ckan-config-storage
@@ -72,10 +76,12 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             {{- toYaml $.Values.securityContext | nindent 12 }}
+            {{- if not .Values.openshift.enabled }}
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
+            {{- end }}
           ports:
             - name: http
               containerPort: 5000

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -76,6 +76,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             {{- toYaml $.Values.securityContext | nindent 12 }}
+            {{- if not .Values.openshift.enabled }}
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault

--- a/templates/psql-init-job.yaml
+++ b/templates/psql-init-job.yaml
@@ -18,15 +18,19 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- if not .Values.openshift.enabled }}
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
+            {{- end }}
             capabilities:
               drop:
                 - ALL
+              {{- if not .Values.openshift.enabled }}
               add:
                 - NET_BIND_SERVICE
+              {{- end }}
           resources:
             requests:
               memory: "64Mi"

--- a/templates/solr-init-job.yaml
+++ b/templates/solr-init-job.yaml
@@ -29,15 +29,19 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             {{- toYaml $.Values.securityContext | nindent 12 }}
+            {{- if not $.Values.openshift.enabled }}
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
+            {{- end }}
             capabilities:
               drop:
                 - ALL
+              {{- if not $.Values.openshift.enabled }}
               add:
                 - NET_BIND_SERVICE
+              {{- end }}
           resources:
             requests:
               memory: "64Mi"

--- a/validators/ckanext-stadgent-validators/ckanext/__init__.py
+++ b/validators/ckanext-stadgent-validators/ckanext/__init__.py
@@ -1,0 +1,2 @@
+# Namespace package
+__import__('pkg_resources').declare_namespace(__name__)

--- a/validators/ckanext-stadgent-validators/ckanext/stadgent_validators/__init__.py
+++ b/validators/ckanext-stadgent-validators/ckanext/stadgent_validators/__init__.py
@@ -1,0 +1,1 @@
+# CKAN extension for Stad Gent custom validators

--- a/validators/ckanext-stadgent-validators/ckanext/stadgent_validators/plugin.py
+++ b/validators/ckanext-stadgent-validators/ckanext/stadgent_validators/plugin.py
@@ -1,0 +1,22 @@
+"""
+CKAN plugin to register Stad Gent custom validators
+"""
+import ckan.plugins as plugins
+import ckan.plugins.toolkit as toolkit
+
+from ckanext.stadgent_validators.validators import project_code_validator
+
+
+class StadGentValidatorsPlugin(plugins.SingletonPlugin):
+    """
+    Plugin to register custom validators for Stad Gent
+    """
+    plugins.implements(plugins.IValidators)
+
+    def get_validators(self):
+        """
+        Register custom validators
+        """
+        return {
+            'project_code_validator': project_code_validator,
+        }

--- a/validators/ckanext-stadgent-validators/ckanext/stadgent_validators/validators.py
+++ b/validators/ckanext-stadgent-validators/ckanext/stadgent_validators/validators.py
@@ -1,0 +1,30 @@
+"""
+Custom validators for Stad Gent CKAN instance
+"""
+import re
+from ckan.plugins.toolkit import Invalid
+
+
+def project_code_validator(value):
+    """
+    Validate project code format: STAD-YYYY-NNN
+
+    Examples:
+        STAD-2024-001
+        STAD-2025-999
+
+    Raises:
+        Invalid: If the format doesn't match
+    """
+    if not value:
+        return value
+
+    # Pattern: STAD-YYYY-NNN (year must be 4 digits, number must be 3 digits)
+    pattern = r'^STAD-\d{4}-\d{3}$'
+
+    if not re.match(pattern, value):
+        raise Invalid(
+            'Projectcode moet het formaat STAD-YYYY-NNN hebben (bijv. STAD-2024-001)'
+        )
+
+    return value

--- a/validators/ckanext-stadgent-validators/setup.py
+++ b/validators/ckanext-stadgent-validators/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='ckanext-stadgent-validators',
+    version='0.1.0',
+    description='Custom validators for Stad Gent CKAN',
+    author='Stad Gent',
+    packages=find_packages(),
+    namespace_packages=['ckanext'],
+    entry_points={
+        'ckan.plugins': [
+            'stadgent_validators = ckanext.stadgent_validators.plugin:StadGentValidatorsPlugin',
+        ],
+    },
+)

--- a/validators/stadgent_validators.py
+++ b/validators/stadgent_validators.py
@@ -1,0 +1,39 @@
+"""
+Custom validators for Stad Gent CKAN instance
+"""
+import re
+from ckan.plugins.toolkit import Invalid
+
+
+def project_code_validator(value):
+    """
+    Validate project code format: STAD-YYYY-NNN
+
+    Examples:
+        STAD-2024-001
+        STAD-2025-999
+
+    Raises:
+        Invalid: If the format doesn't match
+    """
+    if not value:
+        return value
+
+    # Pattern: STAD-YYYY-NNN (year must be 4 digits, number must be 3 digits)
+    pattern = r'^STAD-\d{4}-\d{3}$'
+
+    if not re.match(pattern, value):
+        raise Invalid(
+            'Projectcode moet het formaat STAD-YYYY-NNN hebben (bijv. STAD-2024-001)'
+        )
+
+    return value
+
+
+def get_validators():
+    """
+    Return dictionary of all custom validators
+    """
+    return {
+        'project_code_validator': project_code_validator,
+    }


### PR DESCRIPTION
## Summary

This PR adds OpenShift compatibility to the CKAN Helm chart by making security contexts conditional.

## Changes

- Add `openshift.enabled` flag to enable OpenShift compatibility mode
- Make hardcoded security contexts (runAsUser, runAsNonRoot, seccompProfile) conditional
- Remove NET_BIND_SERVICE capability when OpenShift mode is enabled
- Update 5 templates: deployment.yaml, ckan_workers.yaml, psql-init-job.yaml, solr-init-job.yaml, cronjob.yaml

## Motivation

OpenShift has stricter Security Context Constraints (SCC) than standard Kubernetes:
- UIDs/GIDs are auto-assigned from namespace ranges
- Hardcoded UID/GID values cause pod creation failures
- Certain capabilities like NET_BIND_SERVICE are forbidden
- seccompProfile annotations are not allowed in restricted mode

## Implementation

Templates now use conditional logic:
```yaml
{{- if not .Values.openshift.enabled }}
readOnlyRootFilesystem: true
runAsNonRoot: true
seccompProfile:
  type: RuntimeDefault
{{- end }}
```

When `openshift.enabled: true` is set in values.yaml, OpenShift will automatically:
- Assign UIDs/GIDs from the namespace's allowed range
- Apply the appropriate Security Context Constraints
- Allow pods to run without hardcoded security contexts

## Usage

To deploy on OpenShift, create a values file with:
```yaml
openshift:
  enabled: true

# Let OpenShift auto-assign security contexts
podSecurityContext:
  runAsUser:
  runAsGroup:
  fsGroup:

securityContext:
  allowPrivilegeEscalation: false
  runAsNonRoot:
  capabilities:
    drop:
    - ALL
```

## Testing

Tested successfully on OpenShift 4.x cluster with:
- Restricted SCC (default)
- Namespace UID range
- All pods start and run correctly
- No SCC violations

## Backward Compatibility

This change is fully backward compatible:
- Default behavior unchanged (`openshift.enabled: false`)
- Standard Kubernetes deployments work exactly as before
- Only affects deployments that explicitly set `openshift.enabled: true`

## Related Issues

Fixes OpenShift deployment failures due to SCC violations.
