### PR TITLE
Remove third-party git-auto-commit dependency

### DIFF
--- a/.github/workflows/helm-docs.yml
+++ b/.github/workflows/helm-docs.yml
@@ -32,8 +32,19 @@ jobs:
         run: helm-docs
 
       - name: Commit and Push changes
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: "docs: Auto-generate README.md via helm-docs"
-          file_pattern: README.md
-          skip_dirty_check: false
+        run: |
+          # 1. Configure the git user as the official GitHub Actions Bot
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # 2. Add the README file
+          git add README.md
+
+          # 3. Check if there are changes. If yes, commit and push.
+          if ! git diff-index --quiet HEAD; then
+            echo "Changes detected in README.md. Committing..."
+            git commit -m "docs: Auto-generate README.md via helm-docs"
+            git push
+          else
+            echo "No changes detected. Skipping commit."
+          fi

--- a/.github/workflows/helm-docs.yml
+++ b/.github/workflows/helm-docs.yml
@@ -33,18 +33,19 @@ jobs:
 
       - name: Commit and Push changes
         run: |
-          # 1. Configure the git user as the official GitHub Actions Bot
+          # 1. Configure the git user
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          # 2. Add the README file
+          # 2. Add the README file explicitly
           git add README.md
 
-          # 3. Check if there are changes. If yes, commit and push.
-          if ! git diff-index --quiet HEAD; then
+          # 3. Check if README.md specifically is staged for commit
+          # --cached means "look at what is added to the index"
+          if ! git diff --cached --quiet; then
             echo "Changes detected in README.md. Committing..."
             git commit -m "docs: Auto-generate README.md via helm-docs"
             git push
           else
-            echo "No changes detected. Skipping commit."
+            echo "No changes to README.md detected. Skipping commit."
           fi

--- a/.github/workflows/helm-docs.yml
+++ b/.github/workflows/helm-docs.yml
@@ -41,7 +41,6 @@ jobs:
           git add README.md
 
           # 3. Check if README.md specifically is staged for commit
-          # --cached means "look at what is added to the index"
           if ! git diff --cached --quiet; then
             echo "Changes detected in README.md. Committing..."
             git commit -m "docs: Auto-generate README.md via helm-docs"


### PR DESCRIPTION
*   Replaced the `stefanzweifel/git-auto-commit-action` with a custom script for committing auto-generated `README.md` changes.
*   The custom script now explicitly configures Git user details within the workflow.
*   Added a check to prevent unnecessary commits: changes to `README.md` are now only committed and pushed if actual modifications are detected by `helm-docs`.
