### PR TITLE
Add container sidecart support

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ $ kubectl delete pvc -l release=$release
 | ckan.db.ckanDbUrl | string | `"postgres"` | Url of the PostgreSQL server where the CKAN database is hosted |
 | ckan.db.ckanDbUser | string | `"ckan_default"` | Username of the database to be used by CKAN |
 | ckan.debug | string | `"false"` | Set to true to enable debug mode in CKAN |
+| ckan.extraContainers | list | `[]` | An array to add extra containers to the CKAN pod For example: |
 | ckan.extraEnv | list | `[]` | An array to add extra environment variables For example: extraEnv:   - name: FOO     value: "bar"  |
 | ckan.issues.sendEmailNotifications | string | `"true"` |  |
 | ckan.liveness.failureThreshold | int | `6` | Failure threshold for the liveness probe |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ CKAN Helm Chart
 [Chat on Gitter]: https://badges.gitter.im/gitterHQ/gitter.svg
 [2]: https://gitter.im/keitaroinc/docker-ckan
 
-A Helm chart for CKAN
+A Helm chart for CKAN 
 
 Current chart version is `v4.0.5`
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ CKAN Helm Chart
 [Chat on Gitter]: https://badges.gitter.im/gitterHQ/gitter.svg
 [2]: https://gitter.im/keitaroinc/docker-ckan
 
-A Helm chart for CKAN 
+A Helm chart for CKAN
 
 Current chart version is `v4.0.5`
 

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -37,6 +37,9 @@ spec:
           emptyDir: {}
         - name: ckan-config-storage
           emptyDir: {}
+        {{- with .Values.ckan.extraVolumes }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
       initContainers:
         {{- if .Values.pvc.enabled }}
         - name: set-volume-ownsership
@@ -66,6 +69,7 @@ spec:
           volumeMounts:
             - name: ckan-config-storage
               mountPath: /writable-config
+
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -222,7 +226,6 @@ spec:
             failureThreshold: {{ .Values.ckan.liveness.failureThreshold }}
             timeoutSeconds: {{ .Values.ckan.liveness.timeoutSeconds }}
           {{- end }}
-          
           volumeMounts:
             {{- if .Values.pvc.enabled }}
             - name: ckan
@@ -234,9 +237,14 @@ spec:
             - name: ckan-config-storage
               mountPath: /app/production.ini
               subPath: production.ini
-          
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+
+        # Sidecar containers
+        {{- with .Values.ckan.extraContainers }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -126,6 +126,18 @@ ckan:
     replicas: 1
     command: ["ckan", "-c", "/app/production.ini","jobs", "worker", "priority"]
 
+  # ckan.extraContainers -- An array to add extra containers to the CKAN pod
+  # For example:
+  extraContainers: []
+  # - name: example-sidecar
+  #   image: alpine:3.19
+  #   command:
+  #     - sleep
+  #     - infinity
+  #   volumeMounts:
+  #     - name: ckan
+  #       mountPath: /app/data
+
   psql:
     # ckan.psql.runOnAzure -- Set to true to run on Azure (if true wont run on anything other then azure) set to false to run on other platforms
     runOnAzure: false


### PR DESCRIPTION
### Features

*   **Custom Volumes**: Added support for defining extra volumes in the CKAN pod via `ckan.extraVolumes`.
*   **Sidecar Containers**: Implemented the ability to add sidecar containers to the CKAN pod using `ckan.extraContainers` in `values.yaml`. This allows for extending pod functionality without modifying the main container.
