### PR TITLE
feat: add labels.workers override for worker pod templates

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@master
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true
@@ -70,7 +70,7 @@ jobs:
         run: helm dependency update
 
       - name: Run Trivy vulnerability scanner in IaC mode
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           scan-type: 'config'
           hide-progress: false

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -16,4 +16,4 @@ dependencies:
 description: CKAN Helm chart
 name: ckan
 type: application
-version: v4.0.6
+version: v4.0.7

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -16,4 +16,4 @@ dependencies:
 description: CKAN Helm chart
 name: ckan
 type: application
-version: v4.0.5
+version: v4.0.6

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ CKAN Helm Chart
 
 A Helm chart for CKAN
 
-Current chart version is `v4.0.6`
+Current chart version is `v4.0.7`
 
 This chart deploys a self contained CKAN instance with all of its dependencies. These can be enabled/disabled if they already exist in your infrastructure.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ CKAN Helm Chart
 
 A Helm chart for CKAN
 
-Current chart version is `v4.0.5`
+Current chart version is `v4.0.6`
 
 This chart deploys a self contained CKAN instance with all of its dependencies. These can be enabled/disabled if they already exist in your infrastructure.
 
@@ -160,6 +160,7 @@ $ kubectl delete pvc -l release=$release
 | ingressRoute.host | string | `"chart-example.local"` | Traefik ingress route host |
 | labels.ckan | list | `[]` | Custom labels for CKAN deployment |
 | labels.enabled | bool | `false` | Enable custom labels |
+| labels.workers | object | `{}` | Optional labels applied only to worker pod templates. If not set, workers inherit labels.ckan. |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` | Node selector |
 | podSecurityContext | object | `{"runAsGroup":92,"runAsUser":92}` | Pod security context |

--- a/templates/ckan_workers.yaml
+++ b/templates/ckan_workers.yaml
@@ -19,7 +19,11 @@ spec:
       labels:
         {{- include "ckan-chart.selectorLabels" $ | nindent 8 }}
         {{- if $.Values.labels.enabled }}
+        {{- if $.Values.labels.workers }}
+        {{- $.Values.labels.workers | toYaml | nindent 8 }}
+        {{- else }}
         {{- $.Values.labels.ckan | toYaml | nindent 8 }}
+        {{- end }}
         {{- end }}
     spec:
       {{- with $.Values.imagePullSecrets }}

--- a/values.yaml
+++ b/values.yaml
@@ -246,6 +246,9 @@ labels:
   # labels.enabled -- Enable custom labels
   enabled: false
   ckan: []
+  # labels.workers -- Optional labels applied only to worker pod templates.
+  # If not set, workers inherit labels.ckan.
+  workers: {}
 
 # podSecurityContext -- Pod security context
 podSecurityContext:


### PR DESCRIPTION
## Summary

Add optional `labels.workers` field that, when set, applies to worker pod template labels instead of inheriting from `labels.ckan`.

This allows different labels (e.g. Istio sidecar injection) on the main CKAN pod vs worker pods.

## Usage

```yaml
labels:
  enabled: true
  ckan:
    sidecar.istio.io/inject: "true"   # main pod keeps Istio
  workers:
    sidecar.istio.io/inject: "false"  # workers skip Istio
```

If `labels.workers` is not set (empty `{}`), workers fall back to `labels.ckan` — fully backwards compatible.

## Changes

- `templates/ckan_workers.yaml`: use `labels.workers` for pod template labels when set
- `values.yaml`: add `labels.workers: {}` default
- `Chart.yaml`: bump version to v4.0.6