### PR TITLE
Fix user sessions to use correct envvar format

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -172,7 +172,7 @@ spec:
                 secretKeyRef:
                   name: session-secret
                   key: session_secret
-            - name: SESSION_TYPE
+            - name: CKAN___SESSION_TYPE
               value: {{ .Values.hpa.sessions.session_type | quote }}
             {{- end }}
             - name: CKAN_SOLR_URL


### PR DESCRIPTION
## Problem

When deploying CKAN with multiple replicas, users were randomly getting logged out because each pod stored sessions locally in a cookie. Setting `hpa.sessions.session_type: redis` was intended to move session storage to Redis, but it had no effect.

## Root Cause

The Helm chart was generating the env var as `SESSION_TYPE=redis`. However, `ckanext-envvars` only processes env vars that start with `CKAN` — so `SESSION_TYPE` was silently ignored and CKAN kept reading `SESSION_TYPE = cookie` from `production.ini`.

## Fix

Renamed the env var from `SESSION_TYPE` to `CKAN___SESSION_TYPE`. The `CKAN___` prefix (triple underscore) is the correct `ckanext-envvars` format for config keys that contain underscores — it strips the prefix and preserves the key casing, correctly overriding the ini value with `SESSION_TYPE = redis`.

## Result

All CKAN pods now read and write sessions to a shared Redis instance. Verified by running `redis-cli MONITOR` and confirming that multiple pods are accessing the same session key after login.